### PR TITLE
load fixtures from path relative to the tests so they are runnable outside of the repo too

### DIFF
--- a/okareo_tests/test_client.py
+++ b/okareo_tests/test_client.py
@@ -1,3 +1,4 @@
+import os
 import uuid
 from datetime import datetime
 
@@ -131,7 +132,7 @@ def test_upload_scenario_set(okareo_client: Okareo, httpx_mock: HTTPXMock) -> No
     )
     okareo_client.upload_scenario_set(
         scenario_name="my-test-scenario-1",
-        file_path="./okareo_tests/webbizz_class_seed.jsonl",
+        file_path=os.path.join(os.path.dirname(__file__), "webbizz_class_seed.jsonl"),
     )
 
 

--- a/okareo_tests/test_retrieval.py
+++ b/okareo_tests/test_retrieval.py
@@ -1,3 +1,4 @@
+import os
 from datetime import datetime
 from typing import Any
 
@@ -17,7 +18,7 @@ def okareo_client() -> Okareo:
 
 @pytest.fixture(scope="module")
 def uploaded_scenario_set(okareo_client: Okareo) -> ScenarioSetResponse:
-    file_path = "./okareo_tests/webbizz_1_test_article.jsonl"
+    file_path = os.path.join(os.path.dirname(__file__), "webbizz_1_test_article.jsonl")
     articles: ScenarioSetResponse = okareo_client.upload_scenario_set(
         file_path=file_path, scenario_name=f"test_upload_scenario_set {today_with_time}"
     )


### PR DESCRIPTION
in order to make the sdk testable in other pipelines that use post-deploy tests to verify sdk against backend