### PR TITLE
Upgrading httpx-version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ packages = [
 
 [tool.poetry.dependencies]
 python = ">=3.9, <4.0"
-httpx = ">=0.23"
+httpx = ">=0.25"
 types-python-dateutil = "^2.8.19.14"
 langchain = {version = "^0.0.321", optional = true}
 openai = {version = "^0.28.1", optional = true}


### PR DESCRIPTION
Reason:
pytest-httpx 0.27.0 requires httpx==0.25.*

## Description

A short description about the changes in this pull request. If the pull request is related to some issue, mention it
 here.

## Checklist

- [ ] Tests covering the new functionality have been added
- [ ] Documentation has been updated OR the change is too minor to be documented
- [ ] Changes are listed in the `CHANGELOG.md` OR changes are insignificant
