### PR TITLE
fix tests using `register_model` without explicit `model`

### DIFF
--- a/okareo_tests/test_model_under_test.py
+++ b/okareo_tests/test_model_under_test.py
@@ -14,6 +14,9 @@ from okareo_api_client.models import SeedData
 from okareo_api_client.models.scenario_set_create import ScenarioSetCreate
 from okareo_api_client.models.test_run_type import TestRunType
 
+class DummyModel(CustomModel):
+    def invoke(self, input_value: str) -> Any:
+        return input_value, {"input": input_value}
 
 def helper_register_model(httpx_mock: HTTPXMock) -> ModelUnderTest:
     fixture = get_mut_fixture("NotebookModel")
@@ -40,7 +43,7 @@ def test_register_model(httpx_mock: HTTPXMock, okareo_api: OkareoAPIhost) -> Non
         httpx_mock.add_response(status_code=201, json=fixture)
 
     okareo = Okareo(api_key=API_KEY, base_path=okareo_api.path)
-    mut = okareo.register_model(name=fixture["name"], tags=fixture["tags"])
+    mut = okareo.register_model(name=fixture["name"], tags=fixture["tags"], model=DummyModel(name=fixture["name"]))
     assert mut.name == fixture["name"]
 
 
@@ -53,7 +56,7 @@ def test_add_datapoint_optional_integration(
         httpx_mock.add_response(status_code=201, json=fixture)
 
     okareo = Okareo(api_key=API_KEY, base_path=okareo_api.path)
-    mut = okareo.register_model(name=fixture["name"], tags=fixture["tags"])
+    mut = okareo.register_model(name=fixture["name"], tags=fixture["tags"], model=DummyModel(name=fixture["name"]))
     dp = mut.add_data_point(
         feedback=0,
         context_token="SOME_CONTEXT_TOKEN",

--- a/okareo_tests/test_model_under_test.py
+++ b/okareo_tests/test_model_under_test.py
@@ -14,9 +14,11 @@ from okareo_api_client.models import SeedData
 from okareo_api_client.models.scenario_set_create import ScenarioSetCreate
 from okareo_api_client.models.test_run_type import TestRunType
 
+
 class DummyModel(CustomModel):
     def invoke(self, input_value: str) -> Any:
         return input_value, {"input": input_value}
+
 
 def helper_register_model(httpx_mock: HTTPXMock) -> ModelUnderTest:
     fixture = get_mut_fixture("NotebookModel")
@@ -43,7 +45,11 @@ def test_register_model(httpx_mock: HTTPXMock, okareo_api: OkareoAPIhost) -> Non
         httpx_mock.add_response(status_code=201, json=fixture)
 
     okareo = Okareo(api_key=API_KEY, base_path=okareo_api.path)
-    mut = okareo.register_model(name=fixture["name"], tags=fixture["tags"], model=DummyModel(name=fixture["name"]))
+    mut = okareo.register_model(
+        name=fixture["name"],
+        tags=fixture["tags"],
+        model=DummyModel(name=fixture["name"]),
+    )
     assert mut.name == fixture["name"]
 
 
@@ -56,7 +62,11 @@ def test_add_datapoint_optional_integration(
         httpx_mock.add_response(status_code=201, json=fixture)
 
     okareo = Okareo(api_key=API_KEY, base_path=okareo_api.path)
-    mut = okareo.register_model(name=fixture["name"], tags=fixture["tags"], model=DummyModel(name=fixture["name"]))
+    mut = okareo.register_model(
+        name=fixture["name"],
+        tags=fixture["tags"],
+        model=DummyModel(name=fixture["name"]),
+    )
     dp = mut.add_data_point(
         feedback=0,
         context_token="SOME_CONTEXT_TOKEN",

--- a/src/okareo/callbacks.py
+++ b/src/okareo/callbacks.py
@@ -8,8 +8,12 @@ from uuid import UUID
 from langchain.callbacks.base import BaseCallbackHandler
 from langchain.schema import AgentAction, AgentFinish, LLMResult
 
+from okareo.model_under_test import CustomModel
 from okareo.okareo import Okareo
 
+class CallbackModel(CustomModel):
+    def invoke(self, input_value: str) -> Any:
+        return input_value, {'input': input_value}
 
 class CallbackHandler(BaseCallbackHandler):
     """
@@ -32,7 +36,12 @@ class CallbackHandler(BaseCallbackHandler):
         self.registered_model = None
         if mut_name:
             self.registered_model = self.okareo.register_model(
-                name=mut_name, tags=["langchain"]
+                name=mut_name,
+                model=CallbackModel(
+                    name=mut_name,
+                ),
+                tags=["langchain"],
+                update=True,
             )
 
     def on_llm_start(
@@ -61,7 +70,14 @@ class CallbackHandler(BaseCallbackHandler):
                 if response.llm_output
                 else "<unknown>"
             )
-            model = self.okareo.register_model(name=model_name, tags=["langchain"])
+            model = self.okareo.register_model(
+                name=model_name,
+                model=CallbackModel(
+                    name=model_name,
+                ),
+                tags=["langchain"],
+                update=True,
+            )
         model.add_data_point(
             input_obj=self.inputs.pop(),
             result_obj={
@@ -91,7 +107,12 @@ class CallbackHandler(BaseCallbackHandler):
 
         if not self.registered_model:
             self.registered_model = self.okareo.register_model(
-                name=class_name, tags=["langchain"]
+                name=class_name,
+                model=CallbackModel(
+                    name=class_name,
+                ),
+                tags=["langchain"],
+                update=True,
             )
         self.inputs.append(
             {

--- a/src/okareo/callbacks.py
+++ b/src/okareo/callbacks.py
@@ -11,9 +11,11 @@ from langchain.schema import AgentAction, AgentFinish, LLMResult
 from okareo.model_under_test import CustomModel
 from okareo.okareo import Okareo
 
+
 class CallbackModel(CustomModel):
     def invoke(self, input_value: str) -> Any:
-        return input_value, {'input': input_value}
+        return input_value, {"input": input_value}
+
 
 class CallbackHandler(BaseCallbackHandler):
     """

--- a/src/okareo/litellm_logger.py
+++ b/src/okareo/litellm_logger.py
@@ -6,8 +6,14 @@ from litellm.integrations.custom_logger import CustomLogger  # type: ignore
 from openai._models import BaseModel as OpenAIObject
 
 from okareo import Okareo
+from okareo.model_under_test import OpenAIModel
 
 dotenv.load_dotenv()
+
+USER_PROMPT_TEMPLATE = "{input}"
+SYSTEM_PROMPT_TEMPLATE = """
+    Respond to questions about U.S. Presidents.
+"""
 
 
 class LiteLLMLogger(CustomLogger):  # type: ignore
@@ -25,7 +31,17 @@ class LiteLLMLogger(CustomLogger):  # type: ignore
             self.okareo = Okareo(api_key)
 
         self.context_token = context_token
-        self.registered_model = self.okareo.register_model(name=mut_name, tags=tags)
+        self.registered_model = self.okareo.register_model(
+            name=mut_name,
+            tags=tags,
+            model=OpenAIModel(
+                model_id="gpt-3.5-turbo-0125",
+                temperature=0,
+                system_prompt_template=SYSTEM_PROMPT_TEMPLATE,
+                user_prompt_template=USER_PROMPT_TEMPLATE,
+            ),
+            update=True,
+        )
 
     def log_success_event(
         self, kwargs: Any, response_obj: Any, start_time: Any, end_time: Any

--- a/src/okareo/litellm_logger.py
+++ b/src/okareo/litellm_logger.py
@@ -6,14 +6,14 @@ from litellm.integrations.custom_logger import CustomLogger  # type: ignore
 from openai._models import BaseModel as OpenAIObject
 
 from okareo import Okareo
-from okareo.model_under_test import OpenAIModel
+from okareo.model_under_test import CustomModel
 
 dotenv.load_dotenv()
 
-USER_PROMPT_TEMPLATE = "{input}"
-SYSTEM_PROMPT_TEMPLATE = """
-    Respond to questions about U.S. Presidents.
-"""
+
+class LoggerModel(CustomModel):
+    def invoke(self, input_value: str) -> Any:
+        return input_value, {"input": input_value}
 
 
 class LiteLLMLogger(CustomLogger):  # type: ignore
@@ -34,12 +34,7 @@ class LiteLLMLogger(CustomLogger):  # type: ignore
         self.registered_model = self.okareo.register_model(
             name=mut_name,
             tags=tags,
-            model=OpenAIModel(
-                model_id="gpt-3.5-turbo-0125",
-                temperature=0,
-                system_prompt_template=SYSTEM_PROMPT_TEMPLATE,
-                user_prompt_template=USER_PROMPT_TEMPLATE,
-            ),
+            model=LoggerModel(name=mut_name),
             update=True,
         )
 


### PR DESCRIPTION
## Description

Testfix to accommodate change to `ModelUnderTestResponse`.

- [ ] Tests covering the new functionality have been added
- [ ] Documentation has been updated OR the change is too minor to be documented
- [ ] Changes are listed in the `CHANGELOG.md` OR changes are insignificant
