### PR TITLE
predefined checks fixes + bump version to 0.0.53

### DIFF
--- a/okareo_tests/test_checks.py
+++ b/okareo_tests/test_checks.py
@@ -1,16 +1,11 @@
 import os
-import random
-import string
 import tempfile
-from datetime import datetime
 
 import pytest
-from okareo_tests.common import API_KEY
+from okareo_tests.common import API_KEY, random_string
 
 from okareo import Okareo
 from okareo_api_client.models import EvaluatorSpecRequest
-
-today_with_time = datetime.now().strftime("%m-%d %H:%M:%S")
 
 
 @pytest.fixture(scope="module")
@@ -48,13 +43,12 @@ def test_generate_and_upload_check(okareo_client: Okareo) -> None:
     )
     check = okareo_client.generate_check(generate_request)
     assert check.generated_code
-    random_string = "".join(random.choices(string.ascii_letters, k=5))
     temp_dir = tempfile.gettempdir()
     file_path = os.path.join(temp_dir, "sample_check.py")
     with open(file_path, "w+") as file:
         file.write(check.generated_code)
     uploaded_check = okareo_client.upload_check(
-        name=f"test_upload_check {random_string}",
+        name=f"test_upload_check {random_string(5)}",
         file_path=file_path,
         requires_scenario_input=False,
         requires_scenario_result=False,

--- a/okareo_tests/test_checks.py
+++ b/okareo_tests/test_checks.py
@@ -11,23 +11,6 @@ from okareo import Okareo
 from okareo_api_client.models import EvaluatorSpecRequest
 
 today_with_time = datetime.now().strftime("%m-%d %H:%M:%S")
-PREDEFINED_CHECKS = [
-    "levenshtein_distance",
-    "levenshtein_distance_input",
-    "compression_ratio",
-    "does_code_compile",
-    "contains_all_imports",
-    "corpus_BLEU",
-    "coherence_summary",
-    "consistency_summary",
-    "fluency_summary",
-    "relevance_summary",
-    "consistency",
-    "coherence",
-    "conciseness",
-    "fluency",
-    "uniqueness",
-]
 
 
 @pytest.fixture(scope="module")

--- a/okareo_tests/test_client.py
+++ b/okareo_tests/test_client.py
@@ -126,6 +126,6 @@ def test_get_scenario_data_points(okareo_client: Okareo, httpx_mock: HTTPXMock) 
     okareo_client.get_scenario_data_points(scenario_id="scenario-id")
 
 
-def test_get_all_evaluators(okareo_client: Okareo, httpx_mock: HTTPXMock) -> None:
+def test_get_all_checks(okareo_client: Okareo, httpx_mock: HTTPXMock) -> None:
     httpx_mock.add_response(json={}, status_code=201)
-    okareo_client.get_all_evaluators()
+    okareo_client.get_all_checks()

--- a/okareo_tests/test_integration_model_under_test.py
+++ b/okareo_tests/test_integration_model_under_test.py
@@ -399,6 +399,7 @@ def test_run_test_predefined_checks(
         "compression_ratio",
         "does_code_compile",
         "contains_all_imports",
+        "corpus_BLEU",
     ]
     run_resp = mut.run_test(
         name=f"openai-chat-run-predefined-{rnd}",

--- a/okareo_tests/test_json_scenario.py
+++ b/okareo_tests/test_json_scenario.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from typing import Any, Union
 
 import pytest
-from okareo_tests.common import API_KEY
+from okareo_tests.common import API_KEY, random_string
 
 from okareo import Okareo
 from okareo.model_under_test import CohereModel, CustomModel, OpenAIModel
@@ -13,9 +13,11 @@ from okareo_api_client.models.scenario_set_create import ScenarioSetCreate
 from okareo_api_client.models.test_run_item_model_metrics import TestRunItemModelMetrics
 
 today_with_time = datetime.now().strftime("%m-%d %H:%M:%S")
-upload_scenario_name = f"ci_json_test_upload_scenario_set {today_with_time}"
-create_scenario_name = f"ci_json_test_create_scenarios {today_with_time}"
-generate_scenario_name = f"ci_json_test_generate_scenarios {today_with_time}"
+rnd_str = random_string(5)
+unique_key = f"{rnd_str} {today_with_time}"
+upload_scenario_name = f"ci_json_test_upload_scenario_set {unique_key}"
+create_scenario_name = f"ci_json_test_create_scenarios {unique_key}"
+generate_scenario_name = f"ci_json_test_generate_scenarios {unique_key}"
 
 
 @pytest.fixture(scope="module")

--- a/okareo_tests/test_projects.py
+++ b/okareo_tests/test_projects.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from typing import Any, List, Union
 
 import pytest
-from okareo_tests.common import API_KEY
+from okareo_tests.common import API_KEY, random_string
 
 from okareo import Okareo
 from okareo.model_under_test import CustomModel
@@ -16,7 +16,7 @@ from okareo_api_client.models.test_run_type import TestRunType
 
 @pytest.fixture(scope="module")
 def rnd() -> str:
-    return datetime.now().strftime("%Y%m%d%H%M%S")
+    return f'{random_string(5)} {datetime.now().strftime("%Y%m%d%H%M%S")}'
 
 
 @pytest.fixture(scope="module")

--- a/okareo_tests/test_retrieval.py
+++ b/okareo_tests/test_retrieval.py
@@ -3,13 +3,15 @@ from datetime import datetime
 from typing import Any, Union
 
 import pytest
-from okareo_tests.common import API_KEY
+from okareo_tests.common import API_KEY, random_string
 
 from okareo import Okareo
 from okareo.model_under_test import CustomModel
 from okareo_api_client.models import ScenarioSetResponse, ScenarioType, TestRunType
 
 today_with_time = datetime.now().strftime("%m-%d %H:%M:%S")
+rnd_str = random_string(5)
+unique_key = f"{rnd_str} {today_with_time}"
 
 
 @pytest.fixture(scope="module")
@@ -21,7 +23,7 @@ def okareo_client() -> Okareo:
 def uploaded_scenario_set(okareo_client: Okareo) -> ScenarioSetResponse:
     file_path = os.path.join(os.path.dirname(__file__), "webbizz_3_test_article.jsonl")
     articles: ScenarioSetResponse = okareo_client.upload_scenario_set(
-        file_path=file_path, scenario_name=f"test_upload_scenario_set {today_with_time}"
+        file_path=file_path, scenario_name=f"test_upload_scenario_set {unique_key}"
     )
 
     return articles
@@ -33,7 +35,7 @@ def generate_scenarios(
 ) -> ScenarioSetResponse:
     questions: ScenarioSetResponse = okareo_client.generate_scenarios(
         source_scenario=uploaded_scenario_set.scenario_id,
-        name=f"test_generate_scenarios {today_with_time}",
+        name=f"test_generate_scenarios {unique_key}",
         number_examples=2,
         generation_type=ScenarioType.TEXT_REVERSE_QUESTION,
     )

--- a/okareo_tests/test_scenarios.py
+++ b/okareo_tests/test_scenarios.py
@@ -1,7 +1,6 @@
 import json
 import os
 import time
-from datetime import datetime
 from typing import List
 
 import pytest
@@ -18,8 +17,6 @@ from okareo_api_client.models import (
 from okareo_api_client.models.scenario_data_poin_response import (
     ScenarioDataPoinResponse,
 )
-
-today_with_time = datetime.now().strftime("%m-%d %H:%M:%S")
 
 
 @pytest.fixture(scope="module")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "okareo"
-version = "0.0.52"
+version = "0.0.53"
 description = "Python SDK for interacting with Okareo Cloud APIs"
 authors = [
     "Okareo <info@okareo.com>",


### PR DESCRIPTION
## Description

- [Test] Remove unused PREDEFINED_CHECKS variable
- [Test] Add `corpus_BLEU` to integration test
- [Test] Move `evaluator` to `check` in `test_client.py`
- [Testfix] Make scenario names more random to avoid flaky test failures
- Bump SDK version to 0.0.53

## Checklist

- [ ] Tests covering the new functionality have been added
- [ ] Documentation has been updated OR the change is too minor to be documented
- [ ] Changes are listed in the `CHANGELOG.md` OR changes are insignificant
