### PR TITLE
add find test data points wrapper

### DIFF
--- a/okareo_tests/test_get_data_points.py
+++ b/okareo_tests/test_get_data_points.py
@@ -22,9 +22,6 @@ from okareo_api_client.models.scenario_data_poin_response import (
 from okareo_api_client.models.scenario_data_poin_response_input_type_0 import (
     ScenarioDataPoinResponseInputType0,
 )
-from okareo_api_client.models.scenario_data_poin_response_result_type_0 import (
-    ScenarioDataPoinResponseResultType0,
-)
 from okareo_api_client.models.scenario_set_create import ScenarioSetCreate
 from okareo_api_client.models.test_data_point_item import TestDataPointItem
 from okareo_api_client.models.test_data_point_item_metric_value import (
@@ -35,6 +32,7 @@ today_with_time = datetime.now().strftime("%m-%d %H:%M:%S")
 rnd_str = random_string(5)
 unique_key = f"{rnd_str} {today_with_time}"
 create_scenario_name = f"ci_json_test_get_data_points {unique_key}"
+
 
 @pytest.fixture(scope="module")
 def okareo_client() -> Okareo:
@@ -60,6 +58,7 @@ SCENARIO_RESULTS = [scenario["result"] for scenario in JSON_SCENARIO]  # type: i
 
 JSON_SEED = Okareo.seed_data_from_list(JSON_SCENARIO)  # type: ignore
 
+
 @pytest.fixture(scope="module")
 def create_scenario_set(okareo_client: Okareo) -> ScenarioSetResponse:
 
@@ -69,6 +68,7 @@ def create_scenario_set(okareo_client: Okareo) -> ScenarioSetResponse:
     )
     scenario = okareo_client.create_scenario_set(scenario_set_create)
     return scenario
+
 
 def test_get_data_points(
     okareo_client: Okareo, create_scenario_set: ScenarioSetResponse
@@ -80,7 +80,7 @@ def test_get_data_points(
         def invoke(self, input_value: Union[dict, list, str]) -> Any:
             assert isinstance(input_value, dict)
 
-            return input_value['color'], input_value
+            return input_value["color"], input_value
 
     model_under_test = okareo_client.register_model(
         name=test_run_name,

--- a/okareo_tests/test_get_data_points.py
+++ b/okareo_tests/test_get_data_points.py
@@ -1,0 +1,142 @@
+from datetime import datetime
+from typing import Any, Union
+
+import pytest
+from okareo_tests.common import API_KEY, random_string
+
+from okareo import Okareo
+from okareo.model_under_test import CustomModel
+from okareo_api_client.models import (
+    DatapointListItemInputType0,
+    DatapointListItemResultType0,
+    ScenarioSetResponse,
+    TestRunType,
+)
+from okareo_api_client.models.datapoint_search import DatapointSearch
+from okareo_api_client.models.find_test_data_point_payload import (
+    FindTestDataPointPayload,
+)
+from okareo_api_client.models.scenario_data_poin_response import (
+    ScenarioDataPoinResponse,
+)
+from okareo_api_client.models.scenario_data_poin_response_input_type_0 import (
+    ScenarioDataPoinResponseInputType0,
+)
+from okareo_api_client.models.scenario_data_poin_response_result_type_0 import (
+    ScenarioDataPoinResponseResultType0,
+)
+from okareo_api_client.models.scenario_set_create import ScenarioSetCreate
+from okareo_api_client.models.test_data_point_item import TestDataPointItem
+from okareo_api_client.models.test_data_point_item_metric_value import (
+    TestDataPointItemMetricValue,
+)
+
+today_with_time = datetime.now().strftime("%m-%d %H:%M:%S")
+rnd_str = random_string(5)
+unique_key = f"{rnd_str} {today_with_time}"
+create_scenario_name = f"ci_json_test_get_data_points {unique_key}"
+
+@pytest.fixture(scope="module")
+def okareo_client() -> Okareo:
+    return Okareo(api_key=API_KEY)
+
+
+JSON_SCENARIO = [
+    {
+        "input": {"animal": "fish", "color": "red"},
+        "result": "red",
+    },
+    {
+        "input": {"animal": "dog", "color": "blue"},
+        "result": "blue",
+    },
+    {
+        "input": {"animal": "cat", "color": "green"},
+        "result": "green",
+    },
+]  # type: ignore
+SCENARIO_INPUTS = [scenario["input"]["animal"] for scenario in JSON_SCENARIO]  # type: ignore
+SCENARIO_RESULTS = [scenario["result"] for scenario in JSON_SCENARIO]  # type: ignore
+
+JSON_SEED = Okareo.seed_data_from_list(JSON_SCENARIO)  # type: ignore
+
+@pytest.fixture(scope="module")
+def create_scenario_set(okareo_client: Okareo) -> ScenarioSetResponse:
+
+    scenario_set_create = ScenarioSetCreate(
+        name=create_scenario_name,
+        seed_data=JSON_SEED,
+    )
+    scenario = okareo_client.create_scenario_set(scenario_set_create)
+    return scenario
+
+def test_get_data_points(
+    okareo_client: Okareo, create_scenario_set: ScenarioSetResponse
+) -> None:
+
+    test_run_name = f"ci_test_get_data_points {unique_key}"
+
+    class ClassificationModel(CustomModel):
+        def invoke(self, input_value: Union[dict, list, str]) -> Any:
+            assert isinstance(input_value, dict)
+
+            return input_value['color'], input_value
+
+    model_under_test = okareo_client.register_model(
+        name=test_run_name,
+        model=ClassificationModel(name=test_run_name),
+    )
+
+    test_run = model_under_test.run_test(
+        scenario=create_scenario_set,
+        name=test_run_name,
+        test_run_type=TestRunType.MULTI_CLASS_CLASSIFICATION,
+        calculate_metrics=True,
+    )
+
+    assert test_run.id
+    assert test_run.model_metrics
+    metrics_dict = test_run.model_metrics.to_dict()
+    assert metrics_dict["weighted_average"] is not None
+    assert metrics_dict["weighted_average"]["f1"] == 1
+
+    dp = okareo_client.find_datapoints(DatapointSearch(test_run_id=test_run.id))
+    assert isinstance(dp, list)
+    assert len(dp) == 3
+    for d in dp:
+        assert isinstance(d.input_, DatapointListItemInputType0)
+        assert d.input_["animal"] in SCENARIO_INPUTS
+        assert d.input_["color"] in SCENARIO_RESULTS
+        assert isinstance(d.result, DatapointListItemResultType0)
+        assert d.result["animal"] in SCENARIO_INPUTS
+        assert d.result["color"] in SCENARIO_RESULTS
+
+    sdp = okareo_client.get_scenario_data_points(
+        scenario_id=create_scenario_set.scenario_id
+    )
+    assert isinstance(sdp, list)
+    assert len(sdp) == 3
+    for sd in sdp:
+        assert isinstance(sd, ScenarioDataPoinResponse)
+        assert isinstance(sd.input_, ScenarioDataPoinResponseInputType0)
+        assert sd.input_.additional_properties["animal"] in SCENARIO_INPUTS
+        assert sd.input_.additional_properties["color"] in SCENARIO_RESULTS
+        assert sd.result in SCENARIO_RESULTS
+
+    scenario_ids = [s.id for s in sdp]
+
+    tdp = okareo_client.find_test_data_points(
+        FindTestDataPointPayload(test_run_id=test_run.id)
+    )
+    assert isinstance(tdp, list)
+    assert len(dp) == 3
+    for td in tdp:
+        assert isinstance(td, TestDataPointItem)
+        assert td.scenario_data_point_id in scenario_ids
+        assert td.test_run_id == test_run.id
+        assert td.metric_type == "MULTI_CLASS_CLASSIFICATION"
+        assert isinstance(td.metric_value, TestDataPointItemMetricValue)
+        assert (
+            td.metric_value.additional_properties["expected"]
+            == td.metric_value.additional_properties["actual"]
+        )

--- a/src/okareo/okareo.py
+++ b/src/okareo/okareo.py
@@ -299,10 +299,10 @@ class Okareo:
         return response
 
     def find_test_data_points(
-        self, test_datapoint_payload: FindTestDataPointPayload
+        self, test_data_point_payload: FindTestDataPointPayload
     ) -> Union[List[TestDataPointItem], ErrorResponse]:
         data = find_test_data_points_v0_find_test_data_points_post.sync(
-            client=self.client, api_key=self.api_key, json_body=test_datapoint_payload
+            client=self.client, api_key=self.api_key, json_body=test_data_point_payload
         )
         if not data:
             return []

--- a/src/okareo/okareo.py
+++ b/src/okareo/okareo.py
@@ -11,6 +11,7 @@ from okareo_api_client.api.default import (
     check_upload_v0_check_upload_post,
     create_project_v0_projects_post,
     create_scenario_set_v0_scenario_sets_post,
+    find_test_data_points_v0_find_test_data_points_post,
     generate_scenario_set_v0_scenario_sets_generate_post,
     get_all_checks_v0_checks_get,
     get_all_projects_v0_projects_get,
@@ -41,6 +42,9 @@ from okareo_api_client.models.evaluator_generate_response import (
     EvaluatorGenerateResponse,
 )
 from okareo_api_client.models.evaluator_spec_request import EvaluatorSpecRequest
+from okareo_api_client.models.find_test_data_point_payload import (
+    FindTestDataPointPayload,
+)
 from okareo_api_client.models.model_under_test_response import ModelUnderTestResponse
 from okareo_api_client.models.model_under_test_schema import ModelUnderTestSchema
 from okareo_api_client.models.project_response import ProjectResponse
@@ -55,6 +59,7 @@ from okareo_api_client.models.scenario_type import ScenarioType
 from okareo_api_client.models.seed_data import SeedData
 from okareo_api_client.models.seed_data_input_type_0 import SeedDataInputType0
 from okareo_api_client.models.seed_data_result_type_0 import SeedDataResultType0
+from okareo_api_client.models.test_data_point_item import TestDataPointItem
 from okareo_api_client.types import UNSET, File, Unset
 
 from .common import BASE_URL, HTTPX_TIME_OUT
@@ -292,6 +297,16 @@ class Okareo:
         assert isinstance(response, List)
 
         return response
+
+    def find_test_data_points(
+        self, test_datapoint_payload: FindTestDataPointPayload
+    ) -> Union[List[TestDataPointItem], ErrorResponse]:
+        data = find_test_data_points_v0_find_test_data_points_post.sync(
+            client=self.client, api_key=self.api_key, json_body=test_datapoint_payload
+        )
+        if not data:
+            return []
+        return data
 
     def validate_response(self, response: Any) -> None:
         if isinstance(response, ErrorResponse):


### PR DESCRIPTION
## Description

Adds Python SDK method 'find_test_data_points' to expose API endpoint '/v0/find_test_data_points'

## Checklist

- [X] Tests covering the new functionality have been added
- [X] Documentation has been updated OR the change is too minor to be documented
- [x] Changes are listed in the `CHANGELOG.md` OR changes are insignificant
