### PR TITLE
Raise error for empty seed data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,6 @@ venv.bak/
 
 # Local Development
 local-rebuild.sh
+
+# Models
+examples/webbizz_classification_model

--- a/examples/finetuning/utils.py
+++ b/examples/finetuning/utils.py
@@ -103,7 +103,6 @@ def load_raw_data(data_file_paths):
 def get_model_tokenizer_trainer(
     model_id, finetuned_model_name, dataset, epochs=3, target_modules=None
 ):
-
     # BitsAndBytesConfig int-4 config
     bnb_config = BitsAndBytesConfig(
         load_in_4bit=True,

--- a/okareo_tests/test_client.py
+++ b/okareo_tests/test_client.py
@@ -62,7 +62,7 @@ def test_create_scenario_set(httpx_mock: HTTPXMock, okareo_api: OkareoAPIhost) -
     okareo = Okareo(api_key=API_KEY, base_path=okareo_api.path)
     scenario_request = ScenarioSetCreate(
         name="test_scenario",
-        seed_data=[SeedData(input="foo", result="bar")],
+        seed_data=[SeedData(input_="foo", result="bar")],
         project_id="project_id" if okareo_api.is_mock else UNSET,
     )
     scenario_response = okareo.create_scenario_set(scenario_request)

--- a/okareo_tests/test_client.py
+++ b/okareo_tests/test_client.py
@@ -62,7 +62,7 @@ def test_create_scenario_set(httpx_mock: HTTPXMock, okareo_api: OkareoAPIhost) -
     okareo = Okareo(api_key=API_KEY, base_path=okareo_api.path)
     scenario_request = ScenarioSetCreate(
         name="test_scenario",
-        seed_data=[],
+        seed_data=[SeedData(input="foo", result="bar")],
         project_id="project_id" if okareo_api.is_mock else UNSET,
     )
     scenario_response = okareo.create_scenario_set(scenario_request)

--- a/okareo_tests/test_dialog_scenario.py
+++ b/okareo_tests/test_dialog_scenario.py
@@ -71,7 +71,6 @@ JSON_DAILOG = Okareo.seed_data_from_list(
 
 @pytest.fixture(scope="module")
 def create_scenario_set(okareo_client: Okareo) -> ScenarioSetResponse:
-
     scenario_set_create = ScenarioSetCreate(
         name=create_scenario_name,
         seed_data=JSON_DAILOG,
@@ -89,7 +88,6 @@ def test_create_scenario_set(
 def test_dialog_input(
     okareo_client: Okareo, create_scenario_set: ScenarioSetResponse
 ) -> None:
-
     test_run_name = f"ci_test_dialog_scenarios_openai {unique_key}"
 
     mut = okareo_client.register_model(
@@ -132,7 +130,6 @@ DAILOG_TEMPLATE = """
 def test_dialog_template(
     okareo_client: Okareo, create_scenario_set: ScenarioSetResponse
 ) -> None:
-
     test_run_name = f"ci_test_dialog_template_openai {unique_key}"
 
     mut = okareo_client.register_model(

--- a/okareo_tests/test_get_data_points.py
+++ b/okareo_tests/test_get_data_points.py
@@ -61,7 +61,6 @@ JSON_SEED = Okareo.seed_data_from_list(JSON_SCENARIO)  # type: ignore
 
 @pytest.fixture(scope="module")
 def create_scenario_set(okareo_client: Okareo) -> ScenarioSetResponse:
-
     scenario_set_create = ScenarioSetCreate(
         name=create_scenario_name,
         seed_data=JSON_SEED,
@@ -73,7 +72,6 @@ def create_scenario_set(okareo_client: Okareo) -> ScenarioSetResponse:
 def test_get_data_points(
     okareo_client: Okareo, create_scenario_set: ScenarioSetResponse
 ) -> None:
-
     test_run_name = f"ci_test_get_data_points {unique_key}"
 
     class ClassificationModel(CustomModel):

--- a/okareo_tests/test_integration_model_under_test.py
+++ b/okareo_tests/test_integration_model_under_test.py
@@ -458,7 +458,6 @@ def test_run_test_custom_ir_tags(
     assert new_test_data_points[0].tags == ["ci-testing"]
 
     class RetrievalModelNew(CustomModel):
-
         def invoke(self, model_input: Any) -> Any:
             results = {
                 "ids": [

--- a/okareo_tests/test_json_scenario.py
+++ b/okareo_tests/test_json_scenario.py
@@ -82,7 +82,6 @@ JSON_SEED = Okareo.seed_data_from_list(
 
 
 def test_create_scenario_set(okareo_client: Okareo) -> ScenarioSetResponse:
-
     scenario_set_create = ScenarioSetCreate(
         name=create_scenario_name,
         seed_data=JSON_SEED,
@@ -249,7 +248,6 @@ def test_custom_retrieval(
 def test_generation_openai(
     okareo_client: Okareo, uploaded_scenario_set: ScenarioSetResponse
 ) -> None:
-
     test_run_name = f"ci_json_test_generation_openai {today_with_time}"
 
     mut = okareo_client.register_model(

--- a/okareo_tests/test_model_invocation.py
+++ b/okareo_tests/test_model_invocation.py
@@ -49,7 +49,6 @@ JSON_SEED = Okareo.seed_data_from_list(JSON_SCENARIO)  # type: ignore
 
 @pytest.fixture(scope="module")
 def create_scenario_set(okareo_client: Okareo) -> ScenarioSetResponse:
-
     scenario_set_create = ScenarioSetCreate(
         name=create_scenario_name,
         seed_data=JSON_SEED,
@@ -61,7 +60,6 @@ def create_scenario_set(okareo_client: Okareo) -> ScenarioSetResponse:
 def test_custom_return_bc(
     okareo_client: Okareo, create_scenario_set: ScenarioSetResponse
 ) -> None:
-
     test_run_name = f"ci_test_custom_return_bc {unique_key}"
 
     class ClassificationModel(CustomModel):
@@ -100,7 +98,6 @@ def test_custom_return_bc(
 def test_custom_return_invocation(
     okareo_client: Okareo, create_scenario_set: ScenarioSetResponse
 ) -> None:
-
     test_run_name = f"ci_test_custom_return_bc {unique_key}"
 
     class ClassificationModel(CustomModel):

--- a/okareo_tests/test_scenario_template.py
+++ b/okareo_tests/test_scenario_template.py
@@ -52,7 +52,6 @@ JSON_SEED = Okareo.seed_data_from_list(JSON_SCENARIO)  # type: ignore
 
 @pytest.fixture(scope="module")
 def create_scenario_set(okareo_client: Okareo) -> ScenarioSetResponse:
-
     scenario_set_create = ScenarioSetCreate(
         name=create_scenario_name,
         seed_data=JSON_SEED,
@@ -65,7 +64,6 @@ def create_scenario_set(okareo_client: Okareo) -> ScenarioSetResponse:
 def generate_scenarios(
     okareo_client: Okareo, create_scenario_set: ScenarioSetResponse
 ) -> ScenarioSetResponse:
-
     questions: ScenarioSetResponse = okareo_client.generate_scenario_set(
         ScenarioSetGenerate(
             name=generate_scenario_name,
@@ -115,7 +113,6 @@ def test_generate_scenarios(
 def test_custom_retrieval(
     okareo_client: Okareo, generate_scenarios: ScenarioSetResponse
 ) -> None:
-
     test_run_name = f"ci_scenario_template_custom {unique_key}"
 
     class RetrievalModel(CustomModel):

--- a/okareo_tests/test_scenarios.py
+++ b/okareo_tests/test_scenarios.py
@@ -213,6 +213,7 @@ def delete_scenario_data_points(
     }
     requests.delete(url, headers=headers)
 
+
 def test_create_scenario_empty_seed_data(
     okareo_client: Okareo,
 ) -> None:
@@ -220,8 +221,11 @@ def test_create_scenario_empty_seed_data(
         name=f"my test scenario set {random_string(5)}",
         seed_data=[],
     )
-    with pytest.raises(ValueError, match="Non-empty seed data is required to create a scenario set"):
+    with pytest.raises(
+        ValueError, match="Non-empty seed data is required to create a scenario set"
+    ):
         okareo_client.create_scenario_set(scenario_set_create)
+
 
 def dtest_create_delete_scenario_set_contraction_tiny_load(
     okareo_client: Okareo, seed_data: List[SeedData]

--- a/okareo_tests/test_scenarios.py
+++ b/okareo_tests/test_scenarios.py
@@ -43,7 +43,6 @@ create_scenario_name = f"my_test_scenario_set_{random_string(5)}"
 def create_scenario_set(
     okareo_client: Okareo, seed_data: List[SeedData]
 ) -> ScenarioSetResponse:
-
     scenario_set_create = ScenarioSetCreate(
         name=create_scenario_name,
         seed_data=seed_data,
@@ -214,6 +213,15 @@ def delete_scenario_data_points(
     }
     requests.delete(url, headers=headers)
 
+def test_create_scenario_empty_seed_data(
+    okareo_client: Okareo,
+) -> None:
+    scenario_set_create = ScenarioSetCreate(
+        name=f"my test scenario set {random_string(5)}",
+        seed_data=[],
+    )
+    with pytest.raises(ValueError, match="Non-empty seed data is required to create a scenario set"):
+        okareo_client.create_scenario_set(scenario_set_create)
 
 def dtest_create_delete_scenario_set_contraction_tiny_load(
     okareo_client: Okareo, seed_data: List[SeedData]

--- a/src/okareo/okareo.py
+++ b/src/okareo/okareo.py
@@ -188,7 +188,6 @@ class Okareo:
     def create_scenario_set(
         self, create_request: ScenarioSetCreate
     ) -> ScenarioSetResponse:
-        
         if create_request.seed_data == [] or create_request.seed_data is None:
             raise ValueError("Non-empty seed data is required to create a scenario set")
 

--- a/src/okareo/okareo.py
+++ b/src/okareo/okareo.py
@@ -188,6 +188,10 @@ class Okareo:
     def create_scenario_set(
         self, create_request: ScenarioSetCreate
     ) -> ScenarioSetResponse:
+        
+        if create_request.seed_data == [] or create_request.seed_data is None:
+            raise ValueError("Non-empty seed data is required to create a scenario set")
+
         response = create_scenario_set_v0_scenario_sets_post.sync(
             client=self.client, api_key=self.api_key, json_body=create_request
         )


### PR DESCRIPTION
Raise ValueError if empty list or None is used as the value for seed_data when creating a scenario set

## Description

Raise ValueError and prompt the user to provide non-empty data
