### PR TITLE
[autogen] add new session_id per start/end call

### DIFF
--- a/okareo_tests/test_autogen_logger.py
+++ b/okareo_tests/test_autogen_logger.py
@@ -1,0 +1,70 @@
+from typing import Any
+
+from autogen import ConversableAgent  # type: ignore
+from okareo_tests.common import API_KEY, OPENAI_API_KEY, random_string
+
+from okareo import Okareo
+from okareo.autogen_logger import AutogenLogger
+from okareo_api_client.models.datapoint_search import DatapointSearch
+
+
+def get_logger_config() -> dict[str, Any]:
+    logger_config = {
+        "api_key": API_KEY,
+        "tags": ["autogen-test"],
+        "group_name": f"test_autogen_group_{random_string(5)}",
+    }
+    return logger_config
+
+
+def get_gpt_config() -> dict[str, Any]:
+    gpt4_config_list = [
+        {
+            "model": "gpt-4-0125-preview",
+            "api_key": OPENAI_API_KEY,
+        }
+    ]
+
+    gpt4_config = {
+        "cache_seed": 42,  # change the cache_seed for different trials
+        "temperature": 0,
+        "config_list": gpt4_config_list,
+        "timeout": 120,
+    }
+
+    return gpt4_config
+
+
+def call_autogen_agents(message: str) -> None:
+    gpt_config = get_gpt_config()
+
+    cathy = ConversableAgent(
+        "cathy",
+        system_message="Your name is Cathy and you are a part of a duo of comedians.",
+        llm_config=gpt_config,
+        human_input_mode="NEVER",  # Never ask for human input.
+    )
+
+    joe = ConversableAgent(
+        "joe",
+        system_message="Your name is Joe and you are a part of a duo of comedians.",
+        llm_config=gpt_config,
+        human_input_mode="NEVER",  # Never ask for human input.
+    )
+
+    joe.initiate_chat(cathy, message=message)
+
+
+def test_autogen_logger() -> None:
+
+    logger_config = get_logger_config()
+    autogen_logger = AutogenLogger(logger_config)
+
+    with autogen_logger:
+        call_autogen_agents("Tell me a joke")
+
+    session_id_0 = autogen_logger.logger.session_id
+    okareo = Okareo(api_key=API_KEY)
+    dp = okareo.find_datapoints(DatapointSearch(context_token=session_id_0))
+
+    assert isinstance(dp, list)

--- a/src/okareo/autogen_logger.py
+++ b/src/okareo/autogen_logger.py
@@ -56,7 +56,7 @@ class OkareoLogger(BaseLogger):  # type: ignore
         else:
             self.okareo = Okareo(api_key)
 
-        self.session_id = str(config.get("context_token", str(uuid.uuid4())))
+        self.context_token = str(config.get("context_token", ""))
 
         random_suffix = "".join(
             random.choices(string.ascii_lowercase + string.digits, k=5)
@@ -104,6 +104,9 @@ class OkareoLogger(BaseLogger):  # type: ignore
 
     def start(self) -> str:
         """Start the logger and return the session_id."""
+        self.session_id = (
+            self.context_token if len(self.context_token) > 0 else str(uuid.uuid4())
+        )
         try:
             if self.verbose:
                 print(
@@ -456,7 +459,7 @@ class OkareoLogger(BaseLogger):  # type: ignore
             print(f"[Okareo] Evaluating logging Session ID: {self.session_id}")
         self.okareo.create_trace_eval(self.group, self.session_id)
         print(
-            f"[Okareo] Logged data points for autogen chat under group_name '{self.group_name}' with ID '{self.group['id']}'."
+            f"[Okareo] Logged data points with:\n-> Context Token '{self.session_id}'\n-> Group Name '{self.group_name}'\n-> Group ID '{self.group['id']}'"
         )
 
 


### PR DESCRIPTION
## Description

Changes the default behavior of autogen to create a new context_token per start/end call

## Checklist

- [x] Tests covering the new functionality have been added
- [X] Documentation has been updated OR the change is too minor to be documented
- [X] Changes are listed in the `CHANGELOG.md` OR changes are insignificant
