### PR TITLE
add metadata to check response

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "okareo"
-version = "0.0.99"
+version = "0.0.100"
 description = "Python SDK for interacting with Okareo Cloud APIs"
 authors = [
     "Okareo <info@okareo.com>",

--- a/src/okareo/checks.py
+++ b/src/okareo/checks.py
@@ -13,10 +13,12 @@ class CheckResponse:
     Attributes:
         score: The numeric or boolean result of the check.
         explanation: Optional string explanation for the score, if applicable.
+        metadata: Optional dictionary containing metadata about the check. E.g., output tokens, input tokens, latency, cost, etc.
     """
 
     score: Union[bool, int, float]
     explanation: Optional[str] = None
+    metadata: Optional[dict] = None
 
 
 class BaseCheck(ABC):


### PR DESCRIPTION
## Description

- Update `CheckResponse` object to allow metadata. Needed to get checks_metadata working.
- Bump to v0.0.100

## Checklist

- [ ] Tests covering the new functionality have been added
- [ ] Documentation has been updated OR the change is too minor to be documented
- [ ] Changes are listed in the `CHANGELOG.md` OR changes are insignificant
