### PR TITLE
make pydantic method version safe

### DIFF
--- a/src/okareo/okareo.py
+++ b/src/okareo/okareo.py
@@ -5,6 +5,7 @@ import warnings
 from typing import Any, Dict, List, TypedDict, Union
 
 import httpx
+import pydantic
 from pydantic import BaseModel as PydanticBaseModel
 
 from okareo.checks import BaseCheck
@@ -110,7 +111,12 @@ class BaseGenerationSchema(PydanticBaseModel):
 
     @classmethod
     def to_dict(cls) -> dict:
-        return cls.model_json_schema()
+        version_major = int(pydantic.VERSION.split(".")[0])
+        if version_major >= 2:
+            return cls.model_json_schema()
+        else:
+            # Workaround for older pydantic versions
+            return cls.schema()
 
 
 class Okareo:


### PR DESCRIPTION
## Description

Updates the `BaseGenerationSchema.to_dict` method to use a version-safe call of the underlying `schema` method. Fixes a test error when the environment is using pydantic=1.X.X, which is happening in our server deployment.

## Checklist

- [ ] Tests covering the new functionality have been added
- [ ] Documentation has been updated OR the change is too minor to be documented
- [ ] Changes are listed in the `CHANGELOG.md` OR changes are insignificant
