### PR TITLE
add support for base_path in GenerationModel

### DIFF
--- a/okareo_tests/common.py
+++ b/okareo_tests/common.py
@@ -8,6 +8,7 @@ import pytest
 from okareo.common import BASE_URL
 
 API_KEY = os.environ.get("OKAREO_API_KEY", "no-api-key")
+PROXY_URL = os.environ.get("PROXY_URL", "http://host.docker.internal:4000")
 
 
 class OkareoAPIhost:

--- a/src/okareo/model_under_test.py
+++ b/src/okareo/model_under_test.py
@@ -966,6 +966,8 @@ class GenerationModel(BaseModel):
         user_prompt_template: `User` role prompt template to pass to the model. Uses mustache syntax for variable substitution, e.g. `{scenario_input}`
         dialog_template: Dialog template in OpenAI message format to pass to the model. Uses mustache syntax for variable substitution.
         tools: List of tools to pass to the model.
+        base_url: Optional base URL to use for the completion request.
+        extra_headers: Optional headers to pass to the completion request for authentication (e.g., 'api-key' or 'Authorization').
     """
 
     type = "generation"
@@ -975,6 +977,8 @@ class GenerationModel(BaseModel):
     user_prompt_template: Optional[str] = None
     dialog_template: Optional[str] = None
     tools: Optional[List] = None
+    base_url: Optional[str] = None
+    extra_headers: Optional[dict] = None
 
     def params(self) -> dict:
         return {
@@ -985,6 +989,8 @@ class GenerationModel(BaseModel):
             "dialog_template": self.dialog_template,
             "type": self.type,
             "tools": self.tools,
+            "base_url": self.base_url,
+            "extra_headers": self.extra_headers,
         }
 
 


### PR DESCRIPTION
## Description

Add support for `base_path` and `extra_headers` in `GenerationModel` class. Enables configuration of custom (or local) endpoints in test runs.

## Checklist

- [ ] Tests covering the new functionality have been added
- [ ] Documentation has been updated OR the change is too minor to be documented
- [ ] Changes are listed in the `CHANGELOG.md` OR changes are insignificant
