### PR TITLE
fix(tests): replace deprecated claude-3-haiku model with claude-haiku…

### DIFF
--- a/okareo_tests/test_generation_model.py
+++ b/okareo_tests/test_generation_model.py
@@ -95,7 +95,7 @@ def test_claude3(
         rnd,
         okareo,
         article_scenario_set,
-        model_id="claude-3-haiku-20240307",
+        model_id="claude-haiku-4-5",
         api_key=os.environ["ANTHROPIC_API_KEY"],
         system_prompt="You are an AI assistant with a flair for dramatic storytelling and exaggeration.",
         user_prompt="Transform this mundane topic into a very brief dramatic story of heroic proportions: {scenario_input}",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "okareo"
-version = "0.0.129"
+version = "0.0.130"
 description = "Python SDK for interacting with Okareo Cloud APIs"
 authors = [
     "Okareo <info@okareo.com>",


### PR DESCRIPTION
…-4-5

claude-3-haiku-20240307 was deprecated by Anthropic and returning not_found_error. Switch to unpinned claude-haiku-4-5 for stability.

## Description

A short description about the changes in this pull request. If the pull request is related to some issue, mention it
 here.

## Checklist

- [ ] Tests covering the new functionality have been added
- [ ] Documentation has been updated OR the change is too minor to be documented
- [ ] Changes are listed in the `CHANGELOG.md` OR changes are insignificant
