### PR TITLE
test(checks): add versioning tests, update compare

### DIFF
--- a/okareo_tests/test_check_versioning.py
+++ b/okareo_tests/test_check_versioning.py
@@ -1,0 +1,414 @@
+"""Integration tests for check versioning (M8 backend).
+
+All check-endpoint calls use raw httpx via okareo.client.get_httpx_client().
+Existing Okareo SDK methods are used for run_test / find_test_data_points.
+Tags are out of scope for this pass.
+"""
+
+from typing import Any, Union, cast
+from uuid import UUID
+
+import pytest
+from okareo_tests.common import API_KEY, random_string
+
+from okareo import Okareo
+from okareo.checks import CheckOutputType, ModelBasedCheck
+from okareo.model_under_test import CustomModel, ModelInvocation
+from okareo_api_client.models.find_test_data_point_payload import (
+    FindTestDataPointPayload,
+)
+from okareo_api_client.models.scenario_set_create import ScenarioSetCreate
+from okareo_api_client.models.seed_data import SeedData
+from okareo_api_client.models.test_run_type import TestRunType
+
+
+@pytest.fixture(scope="module")
+def rnd() -> str:
+    return random_string(10)
+
+
+@pytest.fixture(scope="module")
+def okareo() -> Okareo:
+    return Okareo(api_key=API_KEY)
+
+
+# ---- helpers ----------------------------------------------------------------
+
+
+def _headers(okareo: Okareo) -> dict[str, str]:
+    return {"api-key": okareo.api_key, "Content-Type": "application/json"}
+
+
+def _create_check(
+    okareo: Okareo,
+    name: str,
+    description: str = "test check",
+    prompt_template: str = "Return True if the model_output has more than 3 words. Output: {model_output}",
+    check_type: str = "pass_fail",
+) -> dict[str, Any]:
+    body = {
+        "name": name,
+        "description": description,
+        "check_config": {
+            "prompt_template": prompt_template,
+            "type": check_type,
+        },
+    }
+    resp = okareo.client.get_httpx_client().request(
+        method="post",
+        url="/v0/check_create_or_update",
+        json=body,
+        headers=_headers(okareo),
+    )
+    assert (
+        resp.status_code == 200
+    ), f"Create check failed {resp.status_code}: {resp.text}"
+    return cast(dict[str, Any], resp.json())
+
+
+def _get_check(okareo: Okareo, check_id: str) -> dict[str, Any]:
+    resp = okareo.client.get_httpx_client().request(
+        method="get",
+        url=f"/v0/check/{check_id}",
+        headers=_headers(okareo),
+    )
+    assert resp.status_code in (
+        200,
+        201,
+    ), f"Get check failed {resp.status_code}: {resp.text}"
+    return cast(dict[str, Any], resp.json())
+
+
+def _get_all_checks(okareo: Okareo, all_versions: bool = False) -> list[dict[str, Any]]:
+    url = "/v0/checks"
+    if all_versions:
+        url += "?all-versions=true"
+    resp = okareo.client.get_httpx_client().request(
+        method="get",
+        url=url,
+        headers=_headers(okareo),
+    )
+    assert resp.status_code in (
+        200,
+        201,
+    ), f"Get all checks failed {resp.status_code}: {resp.text}"
+    return cast(list[dict[str, Any]], resp.json())
+
+
+def _delete_check(okareo: Okareo, check_id: str, check_name: str) -> None:
+    resp = okareo.client.get_httpx_client().request(
+        method="delete",
+        url=f"/v0/check/{check_id}",
+        data={"name": check_name},
+        headers={"api-key": okareo.api_key},
+    )
+    assert (
+        resp.status_code == 204
+    ), f"Delete check failed {resp.status_code}: {resp.text}"
+
+
+# ---- Group 1: Version fields on responses -----------------------------------
+
+
+class TestVersionFieldsOnResponses:
+    def test_create_check_returns_version_1(self, okareo: Okareo, rnd: str) -> None:
+        name = f"ver-create-v1-{rnd}"
+        check = _create_check(okareo, name)
+        try:
+            assert check["version"] == 1
+        finally:
+            _delete_check(okareo, check["id"], name)
+
+    def test_get_check_includes_version(self, okareo: Okareo, rnd: str) -> None:
+        name = f"ver-get-single-{rnd}"
+        created = _create_check(okareo, name)
+        try:
+            fetched = _get_check(okareo, created["id"])
+            assert "version" in fetched
+            assert fetched["version"] == 1
+        finally:
+            _delete_check(okareo, created["id"], name)
+
+    def test_get_all_checks_version_on_custom_check(
+        self, okareo: Okareo, rnd: str
+    ) -> None:
+        name = f"ver-list-custom-{rnd}"
+        created = _create_check(okareo, name)
+        try:
+            all_checks = _get_all_checks(okareo)
+            match = [c for c in all_checks if c["id"] == created["id"]]
+            assert (
+                len(match) == 1
+            ), f"Custom check not found in list by id={created['id']}"
+            assert match[0]["version"] is not None
+        finally:
+            _delete_check(okareo, created["id"], name)
+
+
+# ---- Group 2: Versioning behavior -------------------------------------------
+
+
+class TestVersioningBehavior:
+    def test_config_change_creates_new_version(self, okareo: Okareo, rnd: str) -> None:
+        name = f"ver-bump-{rnd}"
+        v1 = _create_check(okareo, name)
+        v1_id = v1["id"]
+        try:
+            v2 = _create_check(
+                okareo,
+                name,
+                prompt_template="Return True if model_output is valid JSON. Output: {model_output}",
+            )
+            assert v2["version"] == 2
+            assert v2["id"] != v1_id
+        finally:
+            _delete_check(okareo, v1_id, name)
+
+    def test_same_config_returns_existing_version(
+        self, okareo: Okareo, rnd: str
+    ) -> None:
+        name = f"ver-no-bump-same-{rnd}"
+        v1 = _create_check(okareo, name, prompt_template="Same prompt {model_output}")
+        try:
+            v1_again = _create_check(
+                okareo, name, prompt_template="Same prompt {model_output}"
+            )
+            assert v1_again["id"] == v1["id"]
+            assert v1_again["version"] == v1["version"]
+        finally:
+            _delete_check(okareo, v1["id"], name)
+
+    def test_description_only_change_no_new_version(
+        self, okareo: Okareo, rnd: str
+    ) -> None:
+        name = f"ver-desc-only-{rnd}"
+        v1 = _create_check(okareo, name, description="original description")
+        try:
+            updated = _create_check(okareo, name, description="updated description")
+            assert updated["id"] == v1["id"]
+            assert updated["version"] == v1["version"]
+        finally:
+            _delete_check(okareo, v1["id"], name)
+
+
+# ---- Group 3: Version history -----------------------------------------------
+
+
+class TestVersionHistory:
+    def test_get_all_checks_default_returns_latest_only(
+        self, okareo: Okareo, rnd: str
+    ) -> None:
+        name = f"ver-hist-latest-{rnd}"
+        v1 = _create_check(okareo, name)
+        v1_id = v1["id"]
+        v2 = _create_check(
+            okareo,
+            name,
+            prompt_template="Different config for v2 {model_output}",
+        )
+        try:
+            all_checks = _get_all_checks(okareo, all_versions=False)
+            matches = [c for c in all_checks if c["name"] == name]
+            assert (
+                len(matches) == 1
+            ), f"Expected 1 entry for '{name}', got {len(matches)}"
+            assert matches[0]["id"] == v2["id"]
+        finally:
+            _delete_check(okareo, v1_id, name)
+
+    def test_get_all_checks_all_versions_returns_history(
+        self, okareo: Okareo, rnd: str
+    ) -> None:
+        name = f"ver-hist-all-{rnd}"
+        v1 = _create_check(okareo, name)
+        v1_id = v1["id"]
+        _create_check(
+            okareo,
+            name,
+            prompt_template="Different config for v2 history {model_output}",
+        )
+        try:
+            all_checks = _get_all_checks(okareo, all_versions=True)
+            matches = [c for c in all_checks if c["name"] == name]
+            assert (
+                len(matches) == 2
+            ), f"Expected 2 entries for '{name}', got {len(matches)}"
+            versions = {c["version"] for c in matches}
+            assert versions == {1, 2}
+        finally:
+            _delete_check(okareo, v1_id, name)
+
+
+# ---- Group 4: Delete archives all versions ----------------------------------
+
+
+class TestDeleteArchivesAllVersions:
+    def test_delete_archives_all_versions(self, okareo: Okareo, rnd: str) -> None:
+        name = f"ver-del-all-{rnd}"
+        v1 = _create_check(okareo, name)
+        v1_id = v1["id"]
+        _create_check(
+            okareo,
+            name,
+            prompt_template="Different config for v2 delete {model_output}",
+        )
+        _delete_check(okareo, v1_id, name)
+
+        all_checks = _get_all_checks(okareo, all_versions=True)
+        matches = [c for c in all_checks if c["name"] == name]
+        assert len(matches) == 0, f"Expected 0 entries after delete, got {len(matches)}"
+
+    def test_deleted_check_name_reusable(self, okareo: Okareo, rnd: str) -> None:
+        name = f"ver-del-reuse-{rnd}"
+        original = _create_check(okareo, name)
+        _delete_check(okareo, original["id"], name)
+
+        reused = _create_check(
+            okareo, name, prompt_template="Reused name check {model_output}"
+        )
+        try:
+            assert reused["version"] == 1
+            assert reused["id"] != original["id"]
+        finally:
+            _delete_check(okareo, reused["id"], name)
+
+
+# ---- Group 5: UUID-based check selection in runs ----------------------------
+
+
+@pytest.fixture(scope="module")
+def versioning_scenario(rnd: str, okareo: Okareo) -> Any:
+    return okareo.create_scenario_set(
+        ScenarioSetCreate(
+            name=f"check-ver-scenario-{rnd}",
+            seed_data=[
+                SeedData(
+                    input_="The quick brown fox jumps over the lazy dog",
+                    result="A fox jumps over a dog",
+                ),
+                SeedData(
+                    input_="Python is a popular programming language",
+                    result="Python is popular",
+                ),
+            ],
+        )
+    )
+
+
+class TestUuidCheckSelection:
+    def test_run_test_with_check_uuid(
+        self, okareo: Okareo, rnd: str, versioning_scenario: Any
+    ) -> None:
+        check_name = f"ver-uuid-run-{rnd}"
+        check = okareo.create_or_update_check(
+            name=check_name,
+            description="Check for UUID run test",
+            check=ModelBasedCheck(
+                prompt_template="Return True if the model_output is not empty. Output: {model_output}",
+                check_type=CheckOutputType.PASS_FAIL,
+            ),
+        )
+        try:
+            mut = okareo.register_model(
+                name=f"ver-uuid-model-{rnd}",
+                model=_SimpleModel(name=f"ver-uuid-model-{rnd}"),
+            )
+            run = mut.run_test(
+                name=f"ver-uuid-run-{rnd}",
+                scenario=versioning_scenario,
+                test_run_type=TestRunType.NL_GENERATION,
+                checks=[str(check.id)],
+            )
+            assert run.id is not None
+
+            tdps = okareo.find_test_data_points(
+                FindTestDataPointPayload(test_run_id=run.id, full_data_point=True)
+            )
+            assert isinstance(tdps, list)
+            assert len(tdps) > 0
+
+            check_id_str = str(check.id)
+            for tdp in tdps:
+                cv_list = None
+                if hasattr(tdp, "check_values") and tdp.check_values is not None:
+                    cv_list = tdp.check_values
+                elif hasattr(tdp, "additional_properties"):
+                    cv_list = tdp.additional_properties.get("check_values")
+
+                if cv_list is not None:
+                    for cv in cv_list:
+                        cv_data = cv if isinstance(cv, dict) else cv.to_dict()
+                        if cv_data.get("name") == check_name:
+                            assert (
+                                cv_data["check_id"] == check_id_str
+                            ), f"Expected check_id={check_id_str} but got {cv_data['check_id']}"
+        finally:
+            okareo.delete_check(cast(UUID, check.id), cast(str, check.name))
+
+    def test_run_test_with_pinned_version(
+        self, okareo: Okareo, rnd: str, versioning_scenario: Any
+    ) -> None:
+        check_name = f"ver-pinned-{rnd}"
+        v1 = okareo.create_or_update_check(
+            name=check_name,
+            description="Pinned v1",
+            check=ModelBasedCheck(
+                prompt_template="Return True if model_output has more than 1 word. Output: {model_output}",
+                check_type=CheckOutputType.PASS_FAIL,
+            ),
+        )
+        v1_id = str(v1.id)
+
+        okareo.create_or_update_check(
+            name=check_name,
+            description="Pinned v2",
+            check=ModelBasedCheck(
+                prompt_template="Return True if model_output is valid JSON. Output: {model_output}",
+                check_type=CheckOutputType.PASS_FAIL,
+            ),
+        )
+        try:
+            mut = okareo.register_model(
+                name=f"ver-pinned-model-{rnd}",
+                model=_SimpleModel(name=f"ver-pinned-model-{rnd}"),
+            )
+            run = mut.run_test(
+                name=f"ver-pinned-run-{rnd}",
+                scenario=versioning_scenario,
+                test_run_type=TestRunType.NL_GENERATION,
+                checks=[v1_id],
+            )
+
+            tdps = okareo.find_test_data_points(
+                FindTestDataPointPayload(test_run_id=run.id, full_data_point=True)
+            )
+            assert isinstance(tdps, list)
+            assert len(tdps) > 0
+
+            for tdp in tdps:
+                check_values = None
+                if hasattr(tdp, "check_values") and tdp.check_values is not None:
+                    check_values = tdp.check_values
+                elif hasattr(tdp, "additional_properties"):
+                    check_values = tdp.additional_properties.get("check_values")
+
+                if check_values is not None:
+                    for cv in check_values:
+                        cv_data = cv if isinstance(cv, dict) else cv.to_dict()
+                        if cv_data.get("name") == check_name:
+                            assert (
+                                cv_data["check_id"] == v1_id
+                            ), f"Expected check_id={v1_id} (v1) but got {cv_data['check_id']}"
+        finally:
+            okareo.delete_check(cast(UUID, v1.id), cast(str, v1.name))
+
+
+# ---- internal model for Group 5 tests ---------------------------------------
+
+
+class _SimpleModel(CustomModel):
+    def invoke(self, input_value: Union[dict, list, str]) -> ModelInvocation:
+        return ModelInvocation(
+            model_prediction=f"Summary: {str(input_value)[:30]}",
+            model_input=input_value,
+        )

--- a/okareo_tests/test_compare_test_runs.py
+++ b/okareo_tests/test_compare_test_runs.py
@@ -209,10 +209,9 @@ def _compare_test_runs(
     control_id: str | None = None,
     variant_id: str | None = None,
     alpha: float = 0.05,
-    include_scenarios: bool = True,
 ) -> dict[str, Any]:
     """Call POST /v0/test_runs/compare directly via the client's httpx instance."""
-    body: dict[str, Any] = {"alpha": alpha, "include_scenarios": include_scenarios}
+    body: dict[str, Any] = {"alpha": alpha}
     if control_id is not None:
         body["control_test_run_id"] = str(control_id)
     if variant_id is not None:
@@ -239,22 +238,22 @@ def test_compare_returns_correct_structure(
     assert result["control_test_run_id"] == str(control_run.id)
     assert result["variant_test_run_id"] == str(variant_run.id)
 
-    assert "scenarios" in result
     assert result["statistical_tests"] is not None
+    assert result.get("trace_statistical_tests") is None
 
 
-def test_compare_scenarios_match_seed_count(
+def test_compare_statistical_tests_shape(
     okareo: Okareo, control_run: Any, variant_run: Any
 ) -> None:
     result = _compare_test_runs(okareo, control_run.id, variant_run.id)
+    stats = result["statistical_tests"]
+    assert stats is not None
 
-    scenarios = result["scenarios"]
-    assert len(scenarios) == len(SEED_DATA)
-
-    for scenario in scenarios:
-        assert "scenario_data_point_id" in scenario
-        assert len(scenario["control"]) >= 1
-        assert len(scenario["variant"]) >= 1
+    assert stats["matched_scenario_count"] == len(SEED_DATA)
+    assert len(stats["pass_fail_checks"]) >= 1
+    assert len(stats["score_checks"]) >= 1
+    assert "correction_method" in stats
+    assert "alpha" in stats
 
 
 def test_compare_pass_fail_checks(
@@ -274,6 +273,7 @@ def test_compare_pass_fail_checks(
     ), f"is_json not found in pass_fail_checks: {pass_fail_checks}"
 
     assert is_json_check["check_type"] == "pass_fail"
+    assert is_json_check.get("check_id") is not None
     assert 0.0 <= is_json_check["control_pass_rate"] <= 1.0
     assert 0.0 <= is_json_check["variant_pass_rate"] <= 1.0
     assert is_json_check["control_pass_rate"] > is_json_check["variant_pass_rate"]
@@ -301,6 +301,7 @@ def test_compare_score_checks(
 
     for check in score_checks:
         assert check["check_type"] == "score"
+        assert check.get("check_id") is not None
         assert isinstance(check["control_summary"], (int, float))
         assert isinstance(check["variant_summary"], (int, float))
         assert isinstance(check["mean_diff"], (int, float))
@@ -333,13 +334,7 @@ def test_compare_single_control_only(
     assert result["control_test_run_id"] == str(control_run.id)
     assert result["variant_test_run_id"] is None
     assert result["statistical_tests"] is None
-
-    scenarios = result["scenarios"]
-    assert len(scenarios) == len(SEED_DATA)
-
-    for scenario in scenarios:
-        assert len(scenario["control"]) >= 1
-        assert scenario["variant"] == []
+    assert result.get("trace_statistical_tests") is None
 
 
 def test_compare_single_variant_only(
@@ -352,13 +347,7 @@ def test_compare_single_variant_only(
     assert result["control_test_run_id"] is None
     assert result["variant_test_run_id"] == str(variant_run.id)
     assert result["statistical_tests"] is None
-
-    scenarios = result["scenarios"]
-    assert len(scenarios) == len(SEED_DATA)
-
-    for scenario in scenarios:
-        assert scenario["control"] == []
-        assert len(scenario["variant"]) >= 1
+    assert result.get("trace_statistical_tests") is None
 
 
 def test_compare_excluded_tie_count(
@@ -418,21 +407,6 @@ def test_compare_custom_alpha(
             f"{check['name']}: significant={check['significant']} but "
             f"p_value_adjusted={check['p_value_adjusted']}"
         )
-
-
-def test_compare_include_scenarios_false(
-    okareo: Okareo, control_run: Any, variant_run: Any
-) -> None:
-    """include_scenarios=False should return empty scenarios but valid stats."""
-    result = _compare_test_runs(
-        okareo, control_run.id, variant_run.id, include_scenarios=False
-    )
-
-    assert result["scenarios"] == []
-    stats = result["statistical_tests"]
-    assert stats is not None
-    assert len(stats["pass_fail_checks"]) >= 1
-    assert len(stats["score_checks"]) >= 1
 
 
 def test_compare_cleanup(okareo: Okareo, control_run: Any, variant_run: Any) -> None:
@@ -504,14 +478,8 @@ def test_compare_with_repeats(
     assert result["control_test_run_id"] == str(control_repeat_run.id)
     assert result["variant_test_run_id"] == str(variant_repeat_run.id)
 
-    scenarios = result["scenarios"]
-    assert len(scenarios) == len(REPEAT_SEED_DATA)
-
-    for scenario in scenarios:
-        assert len(scenario["control"]) == 3
-        assert len(scenario["variant"]) == 3
-
     stats = result["statistical_tests"]
+    assert stats is not None
     assert stats["matched_scenario_count"] == len(REPEAT_SEED_DATA)
 
     binary_names = {c["name"] for c in stats["pass_fail_checks"]}
@@ -520,6 +488,7 @@ def test_compare_with_repeats(
     refusal_check = next(
         c for c in stats["pass_fail_checks"] if c["name"] == "model_refusal"
     )
+    assert refusal_check.get("check_id") is not None
     assert 0.0 <= refusal_check["p_value"] <= 1.0
     assert 0.0 <= refusal_check["p_value_adjusted"] <= 1.0
     assert isinstance(refusal_check["significant"], bool)
@@ -532,9 +501,16 @@ def test_compare_with_repeats(
     lev_check = next(
         c for c in stats["score_checks"] if c["name"] == "levenshtein_distance"
     )
+    assert lev_check.get("check_id") is not None
     assert 0.0 <= lev_check["p_value"] <= 1.0
     assert 0.0 <= lev_check["p_value_adjusted"] <= 1.0
     assert isinstance(lev_check["significant"], bool)
+
+    trace_stats = result.get("trace_statistical_tests")
+    if trace_stats is not None:
+        assert "pass_fail_checks" in trace_stats
+        assert "score_checks" in trace_stats
+        assert "matched_scenario_count" in trace_stats
 
 
 def test_compare_repeat_cleanup(
@@ -601,16 +577,7 @@ def test_compare_classification(
     assert result["control_test_run_id"] == str(clf_control_run.id)
     assert result["variant_test_run_id"] == str(clf_variant_run.id)
     assert result["statistical_tests"] is None
-
-    scenarios = result["scenarios"]
-    assert len(scenarios) == len(CLASSIFICATION_SEED_DATA)
-
-    for scenario in scenarios:
-        assert len(scenario["control"]) >= 1
-        assert len(scenario["variant"]) >= 1
-        ctrl_dp = scenario["control"][0]
-        assert "metric_value" in ctrl_dp
-        assert "metric_type" in ctrl_dp
+    assert result.get("trace_statistical_tests") is None
 
 
 def test_compare_classification_cleanup(
@@ -676,16 +643,7 @@ def test_compare_retrieval(
     assert result["control_test_run_id"] == str(ret_control_run.id)
     assert result["variant_test_run_id"] == str(ret_variant_run.id)
     assert result["statistical_tests"] is None
-
-    scenarios = result["scenarios"]
-    assert len(scenarios) == len(RETRIEVAL_SEED_DATA)
-
-    for scenario in scenarios:
-        assert len(scenario["control"]) >= 1
-        assert len(scenario["variant"]) >= 1
-        ctrl_dp = scenario["control"][0]
-        assert "metric_value" in ctrl_dp
-        assert "metric_type" in ctrl_dp
+    assert result.get("trace_statistical_tests") is None
 
 
 def test_compare_retrieval_cleanup(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "okareo"
-version = "0.0.130"
+version = "0.0.131"
 description = "Python SDK for interacting with Okareo Cloud APIs"
 authors = [
     "Okareo <info@okareo.com>",


### PR DESCRIPTION
The compare API removed `scenarios` and `include_scenarios` from its response and request schemas respectively. Existing compare tests asserted on these removed fields, causing failures against the current backend. This updates all compare tests to align with the current response shape (`statistical_tests`, `trace_statistical_tests`) and adds `check_id` assertions on pass_fail and score check entries.

New test file `test_check_versioning.py` covers the backend check versioning feature: version numbering on create/update, idempotent config re-submission, description-only updates, version history queries via `all-versions`, delete archival across versions, and UUID-based check pinning in test runs.

All tests use raw httpx for check endpoints; no SDK source changes are included.
