### PR TITLE
feat(sdk): accept "latest" in get_check version

### DIFF
--- a/okareo_tests/test_check_versioning.py
+++ b/okareo_tests/test_check_versioning.py
@@ -398,6 +398,24 @@ class TestSDKGetCheckByName:
         finally:
             okareo.delete_check(UUID(v1_id), name)
 
+    def test_get_check_by_name_with_latest_string(
+        self, okareo: Okareo, rnd: str
+    ) -> None:
+        name = f"sdk-getchk-latest-str-{rnd}"
+        v1 = _sdk_check(okareo, name)
+        v1_id = str(v1.id)
+        v2 = _sdk_check(
+            okareo,
+            name,
+            prompt_template="SDK get_check latest string v2 {model_output}",
+        )
+        try:
+            fetched = okareo.get_check(name, version="latest")
+            assert str(fetched.id) == str(v2.id)
+            assert fetched.additional_properties.get("version") == 2
+        finally:
+            okareo.delete_check(UUID(v1_id), name)
+
     def test_get_check_by_name_not_found(self, okareo: Okareo, rnd: str) -> None:
         with pytest.raises(ValueError, match="No check found"):
             okareo.get_check(f"nonexistent-check-{rnd}")

--- a/src/okareo/okareo.py
+++ b/src/okareo/okareo.py
@@ -946,7 +946,7 @@ class Okareo:
     def get_check(
         self,
         check_id: Union[str, UUID],
-        version: Optional[int] = None,
+        version: Union[str, int, None] = None,
     ) -> EvaluatorDetailedResponse:
         """
         Fetch details for a specific check by UUID or by name.
@@ -955,8 +955,9 @@ class Okareo:
             check_id: A check UUID (str or UUID object) **or** a check name
                 (str).  When a name is given the method resolves it to a UUID
                 via the list endpoint.
-            version: Optional version number.  Only used when *check_id* is a
-                name.  ``None`` means "latest version".
+            version: Optional version number or the string ``"latest"``.
+                Only used when *check_id* is a name.  ``None`` and
+                ``"latest"`` both resolve to the most recent version.
 
         Returns:
             EvaluatorDetailedResponse: The detailed response for the specified check.
@@ -971,13 +972,17 @@ class Okareo:
 
         # By name (latest version)
         check = okareo_client.get_check("my_check")
+        check = okareo_client.get_check("my_check", version="latest")
 
         # By name + pinned version
         check = okareo_client.get_check("my_check", version=1)
         ```
         """
+        if isinstance(version, str) and version == "latest":
+            version = None
+
         # If an explicit version is requested, treat check_id as a name.
-        if version is not None:
+        if isinstance(version, int):
             return self._get_check_by_name(str(check_id), version)
 
         # Try to interpret as UUID first.


### PR DESCRIPTION
get_model already accepts version="latest" but get_check only accepted Optional[int], creating an inconsistent API surface.

Widen the version parameter to Union[str, int, None] and normalize "latest" to None before resolution. Use isinstance narrowing so mypy sees an int argument to _get_check_by_name.

This is an additive change to the public get_check API; existing callers using int or None are unaffected.

## Description

A short description about the changes in this pull request. If the pull request is related to some issue, mention it
 here.

## Checklist

- [ ] Tests covering the new functionality have been added
- [ ] Documentation has been updated OR the change is too minor to be documented
- [ ] Changes are listed in the `CHANGELOG.md` OR changes are insignificant
