### PR TITLE
feat(sdk): add twilio send_digits serialization

### DIFF
--- a/okareo_tests/test_model_under_test.py
+++ b/okareo_tests/test_model_under_test.py
@@ -349,6 +349,48 @@ def test_target_to_dict_twilio_marks_auth_token_sensitive() -> None:
     assert payload["target"]["auth_token"] == "super-secret"
 
 
+def test_target_to_dict_twilio_includes_send_digits_and_keeps_sensitive_contract() -> (
+    None
+):
+    tgt = Target(
+        name="Voice Sim Target (Twilio)",
+        target=TwilioVoiceTarget(
+            account_sid="ACxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+            auth_token="super-secret",
+            from_phone_number="+15105551234",
+            to_phone_number="+14155559876",
+            send_digits="wwww1008",
+        ),
+    )
+    payload = tgt.to_dict()
+
+    assert payload["target"]["send_digits"] == "wwww1008"
+    assert payload["sensitive_fields"] == ["auth_token"]
+
+
+def test_twilio_voice_target_params_includes_send_digits() -> None:
+    target = TwilioVoiceTarget(
+        account_sid="ACxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+        auth_token="super-secret",
+        from_phone_number="+15105551234",
+        to_phone_number="+14155559876",
+        send_digits="wwww1008",
+    )
+    payload = target.params()
+    assert payload["send_digits"] == "wwww1008"
+
+
+def test_twilio_voice_target_params_send_digits_defaults_none() -> None:
+    target = TwilioVoiceTarget(
+        account_sid="ACxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+        auth_token="super-secret",
+        from_phone_number="+15105551234",
+        to_phone_number="+14155559876",
+    )
+    payload = target.params()
+    assert payload["send_digits"] is None
+
+
 def test_target_to_dict_twilio_omits_sensitive_when_token_missing() -> None:
     tgt = Target(
         name="Voice Sim Target (Twilio)",

--- a/src/okareo/model_under_test.py
+++ b/src/okareo/model_under_test.py
@@ -1631,6 +1631,7 @@ class TwilioVoiceTarget(VoiceTarget):
         auth_token: Twilio authentication token.
         from_phone_number: Phone number to call from (Twilio number).
         to_phone_number: Phone number to call to (destination number).
+        send_digits: DTMF digits to dial after answer (e.g. "wwww1008").
         max_parallel_requests: Maximum number of parallel requests the target can handle.
     """
 
@@ -1639,6 +1640,7 @@ class TwilioVoiceTarget(VoiceTarget):
     auth_token: str = field(default="")
     from_phone_number: Optional[str] = None
     to_phone_number: Optional[str] = None
+    send_digits: Optional[str] = None
     max_parallel_requests: Optional[int] = None
 
     def params(self) -> dict:
@@ -1649,6 +1651,7 @@ class TwilioVoiceTarget(VoiceTarget):
             "auth_token": self.auth_token,
             "from_phone_number": self.from_phone_number,
             "to_phone_number": self.to_phone_number,
+            "send_digits": self.send_digits,
             "max_parallel_requests": self.max_parallel_requests,
         }
 


### PR DESCRIPTION
Twilio extension dialing must be representable in SDK target payloads so integrators can configure IVR navigation through the same typed contract used by backend and frontend components.

This updates the public TwilioVoiceTarget params surface to carry send_digits while preserving the existing sensitive field behavior, and adds tests to lock the serialization contract.
