### PR TITLE
docs(pydoc): refresh voice/simulation surfaces and module scope

### DIFF
--- a/docs/build_docs_postprocess.py
+++ b/docs/build_docs_postprocess.py
@@ -6,11 +6,6 @@ DIR = f"{BASE_DIR}/okareo"
 
 # Drop files that are not ready for documentation
 DROP_FILES = [
-    f"{DIR}/crewai_logger",
-    f"{DIR}/litellm_logger",
-    f"{DIR}/autogen_logger",
-    f"{DIR}/reporter",
-    f"{DIR}/callbacks",
     f"{DIR}/async_utils",
 ]
 
@@ -19,11 +14,7 @@ DESIRED_ORDER = [
     f"{DIR}/okareo",
     f"{DIR}/model_under_test",
     f"{DIR}/checks",
-    f"{DIR}/autogen_logger",
-    f"{DIR}/crewai_logger",
-    f"{DIR}/litellm_logger",
-    f"{DIR}/reporter",
-    f"{DIR}/callbacks",
+    f"{DIR}/augmentations",
     f"{DIR}/async_utils",
 ]
 CATEGORY_PATH = f"docs/{DIR}/_category_.json"
@@ -46,12 +37,33 @@ def _clean_md_file(content: list[str], sidebar_position: int) -> list[str]:
             new_content.append("###" + line[4:])  # Convert H4 to H2
         elif line.startswith("title: okareo.okareo"):
             line = line.replace("okareo.okareo", "okareo")  # Fix title for okareo.md
+        elif _is_json_like_list_item(line):
+            new_content.append(_quote_json_like_list_item(line))
         else:
             new_content.append(line)
             if line.startswith("---") and not added_order:
                 new_content.append(f"sidebar_position: {sidebar_position}\n")
                 added_order = True
     return new_content
+
+
+def _is_json_like_list_item(line: str) -> bool:
+    stripped = line.lstrip()
+    if stripped.startswith("- `{"):
+        return False
+    return (
+        stripped.startswith("- {")
+        and stripped.rstrip().endswith("}")
+        and ":" in stripped
+    )
+
+
+def _quote_json_like_list_item(line: str) -> str:
+    stripped = line.lstrip()
+    indent = line[: len(line) - len(stripped)]
+    payload = stripped[2:].strip()
+    newline = "\n" if line.endswith("\n") else ""
+    return f"{indent}- `{payload}`{newline}"
 
 
 def _create_category_json() -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,7 @@ scipy-stubs = "*"
 pytest-rerunfailures = "*"
 
 [tool.pydoc-markdown]
-loaders = [{ type = "python", search_path = ["src"], modules = ["okareo.model_under_test", "okareo.checks", "okareo.async_utils", "okareo.autogen_logger", "okareo.callbacks", "okareo.crewai_logger", "okareo.litellm_logger", "okareo.okareo", "okareo.reporter"] }]
+loaders = [{ type = "python", search_path = ["src"], modules = ["okareo.model_under_test", "okareo.checks", "okareo.okareo", "okareo.augmentations"] }]
 
 [tool.pydoc-markdown.renderer]
 type = "docusaurus"

--- a/src/okareo/model_under_test.py
+++ b/src/okareo/model_under_test.py
@@ -1759,12 +1759,19 @@ class StreamingConfig:
     When attached to TurnConfig or SessionConfig, the server can consume SSE
     or NDJSON streams and reassemble the final response text.
 
+    The text extraction path is configured on the parent TurnConfig or
+    SessionConfig via `response_message_path`. For streaming responses, set it
+    to your chunk shape (for example:
+    `response.choices[0].delta.content`).
+
     Arguments:
         stop: List of StreamingStopCondition rules. The stream ends when any
-            stop rule matches.
+            stop rule matches (OR semantics). A stop rule without a `path`
+            matches as a raw string against each SSE `data:` payload, such as
+            `[DONE]`.
         select: List of StreamingSelectCondition rules. All select rules must
-            match before chunk content is extracted. If empty, all chunks are
-            considered.
+            match before chunk content is extracted (AND semantics). If empty,
+            content is extracted from every chunk.
     """
 
     def __init__(
@@ -1833,22 +1840,24 @@ class SessionConfig:
 
 
 class TurnConfig:
-    """Config for a custom API endpoint that continues a conversation by one turn.
+    """Config for a custom API endpoint that continues a session by one turn.
 
     Arguments:
-        url: URL of the endpoint to call.
+        url: URL of the endpoint to call for each next turn.
         method: HTTP method to use. Defaults to POST.
         headers: Headers to include in the request. Supports mustache
-            substitution for latest_message, message_history, and session_id.
-            Defaults to an empty JSON object.
+            substitution using latest_message, message_history, and session_id
+            variables. Defaults to an empty JSON object.
         body: Request body. Supports mustache substitution for
-            latest_message, message_history, and session_id.
+            latest_message, message_history, and session_id variables.
             Defaults to an empty JSON object.
         status_code: Expected HTTP status code of the response.
         response_message_path: Path to extract the model message from the
-            response. Example: response.completion.message.content.
+            response JSON (for example,
+            response.completion.message.content).
         response_session_id_path: Path to extract session ID from the
-            response. Example: response.result.contextId.
+            response JSON (for example, response.result.contextId) so the same
+            conversation session can continue across turns.
         response_tool_calls_path: Path to extract tool calls from the
             response.
     """

--- a/src/okareo/model_under_test.py
+++ b/src/okareo/model_under_test.py
@@ -1551,11 +1551,13 @@ class CustomMultiturnTargetAsync(BaseModel):
 
 class VoiceTarget(BaseModel):
     """
-    Base class for realtime voice targets in Okareo multiturn evaluation.
+    Base class for realtime voice targets in Okareo multiturn simulation.
 
-    This target runs server-side during multiturn evaluations and follows the
-    same API key pattern as other targets: API keys are passed via the
-    `api_keys` parameter in `run_simulation()`.
+    Voice targets are used as `Target.target` when calling
+    `Okareo.run_simulation(...)`. They execute server-side and follow the same
+    API key pattern as other targets (pass keys via `api_keys`).
+
+    Subclasses define provider-specific fields and implement `params()`.
     """
 
     type = "voice"
@@ -1624,14 +1626,14 @@ class DeepgramVoiceTarget(VoiceTarget):
 @_attrs_define
 class TwilioVoiceTarget(VoiceTarget):
     """
-    Twilio voice target for Okareo multiturn evaluation.
+    Twilio-backed voice target for Okareo multiturn simulation.
 
     Arguments:
-        account_sid: Twilio account SID for authentication.
-        auth_token: Twilio authentication token.
-        from_phone_number: Phone number to call from (Twilio number).
-        to_phone_number: Phone number to call to (destination number).
-        max_parallel_requests: Maximum number of parallel requests the target can handle.
+        account_sid: Twilio Account SID.
+        auth_token: Twilio auth token (treated as sensitive).
+        from_phone_number: Outbound Twilio phone number.
+        to_phone_number: Destination number to dial.
+        max_parallel_requests: Optional cap on concurrent calls.
     """
 
     edge_type = "twilio"
@@ -1658,9 +1660,10 @@ class TwilioVoiceTarget(VoiceTarget):
 
 @_attrs_define
 class PhoneTarget(VoiceTarget):
-    """Voice target identified by phone number only.
+    """Phone-number-only voice target for multiturn simulation.
 
-    Okareo handles the telephony provider. You just supply the number to call.
+    Use this when Okareo should manage telephony details. You provide only the
+    destination phone number.
 
     Arguments:
         phone_number: Destination phone number (E.164 format, e.g. "+15551234567").
@@ -1753,22 +1756,15 @@ class StreamingSelectCondition:
 class StreamingConfig:
     """Configuration for streaming responses from a custom API endpoint.
 
-    When provided on a TurnConfig or SessionConfig, the server will consume the
-    endpoint's response as a Server-Sent Events (SSE) or NDJSON stream and
-    reassemble the tokens into the final response.
-
-    The text extraction path is specified via ``response_message_path`` on the
-    parent TurnConfig/SessionConfig — set it to the chunk shape when streaming
-    (e.g., ``response.choices[0].delta.content``).
+    When attached to TurnConfig or SessionConfig, the server can consume SSE
+    or NDJSON streams and reassemble the final response text.
 
     Arguments:
-        stop: List of :class:`StreamingStopCondition` objects. The stream terminates
-            when **any** condition matches (OR semantics). A stop condition
-            without a ``path`` matches as a raw string against the SSE
-            ``data:`` payload before JSON parsing (e.g., ``[DONE]``).
-        select: List of :class:`StreamingSelectCondition` objects. **All** conditions
-            must match for a chunk's content to be extracted (AND semantics).
-            When omitted or empty, content is extracted from every chunk.
+        stop: List of StreamingStopCondition rules. The stream ends when any
+            stop rule matches.
+        select: List of StreamingSelectCondition rules. All select rules must
+            match before chunk content is extracted. If empty, all chunks are
+            considered.
     """
 
     def __init__(
@@ -1837,26 +1833,24 @@ class SessionConfig:
 
 
 class TurnConfig:
-    """
-    Configuration for a custom API endpoint that continues a session/conversation by one turn.
+    """Config for a custom API endpoint that continues a conversation by one turn.
 
     Arguments:
-        url: URL of the endpoint to start the session.
-        method: HTTP method to use for the request. Defaults to `POST`.
-        headers: Headers to include in the request.
-            Supports mustache syntax for variable substitution for `{latest_message}`, `{message_history}`, `{session_id}`.
+        url: URL of the endpoint to call.
+        method: HTTP method to use. Defaults to POST.
+        headers: Headers to include in the request. Supports mustache
+            substitution for latest_message, message_history, and session_id.
             Defaults to an empty JSON object.
-        body: Body to include in the request.
-            Supports mustache syntax for variable substitution for `{latest_message}`, `{message_history}`, `{session_id}`.
+        body: Request body. Supports mustache substitution for
+            latest_message, message_history, and session_id.
             Defaults to an empty JSON object.
         status_code: Expected HTTP status code of the response.
-        response_message_path: Path to extract the model's generated message from the response.
-            E.g., `response.completion.message.content` will parse out the corresponding field of
-            the response JSON object as the model's generated response.
-        response_session_id_path: Path to extract the session ID from the response.
-            E.g., `response.result.contextId` will use the `contextId` field of the response
-            JSON object to set the `session_id` for subsequent turns.
-        response_tool_calls_path: Path to extract tool calls from the response.
+        response_message_path: Path to extract the model message from the
+            response. Example: response.completion.message.content.
+        response_session_id_path: Path to extract session ID from the
+            response. Example: response.result.contextId.
+        response_tool_calls_path: Path to extract tool calls from the
+            response.
     """
 
     def __init__(
@@ -2024,6 +2018,12 @@ class CustomEndpointTarget(BaseModel):
 
 @_attrs_define
 class Driver:
+    """Driver configuration used to simulate the caller side of a conversation.
+
+    Registered via `Okareo.create_or_update_driver(...)` and used by
+    `Okareo.run_simulation(...)`.
+    """
+
     name: str
     prompt_template: str = "{scenario_input}"
     model_id: Optional[str] = None
@@ -2084,6 +2084,12 @@ class Driver:
 
 @_attrs_define
 class Target:
+    """Named simulation target wrapper.
+
+    Wraps one target implementation (text or voice) so it can be created,
+    retrieved, and referenced by name in `Okareo.run_simulation(...)`.
+    """
+
     name: str
     target: Union[
         OpenAIModel,
@@ -2135,6 +2141,12 @@ class Target:
 
 @_attrs_define
 class Simulation:
+    """Simulation runtime parameters for multiturn test runs.
+
+    Includes turn controls, stop conditions, and optional augmentation settings
+    used by `Okareo.run_simulation(...)`.
+    """
+
     stop_check: Union[StopConfig, dict, None] = None
     repeats: Optional[int] = 1
     max_turns: Optional[int] = 5

--- a/src/okareo/okareo.py
+++ b/src/okareo/okareo.py
@@ -1284,13 +1284,14 @@ class Okareo:
         )
 
     def create_or_update_driver(self, driver: Driver) -> Driver:
-        """Create or update a driver.
+        """Create or update a simulation driver by name.
 
         Args:
-            driver: The driver to create or update.
+            driver: Driver definition to register. If a driver with the same
+                name already exists, it is updated.
 
         Returns:
-            The created or updated driver.
+            Driver: The created or updated driver.
         """
         try:
             if driver.temperature is not None:
@@ -1323,13 +1324,13 @@ class Okareo:
         return Driver.from_response(response)
 
     def get_driver_by_name(self, driver_name: str) -> Driver:
-        """Get a driver by its name.
+        """Retrieve a simulation driver by name.
 
         Args:
             driver_name: The name of the driver to retrieve.
 
         Returns:
-            The driver with the specified name.
+            Driver: The driver with the specified name.
         """
         response = get_driver_v0_driver_identifier_get.sync(
             client=self.client,
@@ -1360,13 +1361,14 @@ class Okareo:
         project_id: Optional[str] = None,
         sensitive_fields: Union[List[str], None] = None,
     ) -> Target:
-        """Create or update a target.
+        """Create or update a simulation target by name.
 
         Args:
-            target: The target to create or update.
+            target: Target definition to register. If a target with the same
+                name already exists, it is updated.
 
         Returns:
-            The created or updated target.
+            Target: The created or updated target.
         """
         model_invoker = None
         session_starter = None
@@ -1415,6 +1417,14 @@ class Okareo:
         return Target.from_response(response, target_data)
 
     def get_target_by_name(self, target_name: str) -> Target:
+        """Retrieve a simulation target by name.
+
+        Args:
+            target_name: The name of the target to retrieve.
+
+        Returns:
+            Target: The target with the specified name.
+        """
         response = get_target_model_by_name_v0_target_target_model_name_get.sync(
             client=self.client,
             api_key=self.api_key,
@@ -1452,6 +1462,33 @@ class Okareo:
         sensitive_fields: Union[List[str], None] = None,
         submit: Optional[bool] = False,
     ) -> TestRunItem:
+        """Run a multiturn simulation against a target.
+
+        This method resolves or creates the referenced driver and target,
+        builds Simulation parameters (including optional augmentation), and
+        executes either ModelUnderTest.run_test (blocking) or
+        ModelUnderTest.submit_test (async server-side) using
+        TestRunType.MULTI_TURN.
+
+        Parameter summary:
+        - ``name``: Name of the resulting test run.
+        - ``scenario``: Scenario set object or scenario set ID.
+        - ``target`` / ``driver``: Registered names or object definitions.
+        - ``checks``: Optional checks to execute.
+        - ``stop_check``, ``repeats``, ``max_turns``, ``first_turn``:
+          Turn-flow controls.
+        - ``checks_at_every_turn``, ``concurrent_ask_probability``,
+          ``turn_transition_time``: Runtime simulation controls.
+        - ``augmentation``: Optional augmentation settings.
+        - ``api_key`` / ``api_keys``: Provider credentials for target calls.
+        - ``metrics_kwargs`` / ``calculate_metrics``: Metrics configuration.
+        - ``project_id`` / ``tags`` / ``sensitive_fields``: Registration and
+          metadata controls.
+        - ``submit``: If True, submit asynchronously via
+          ModelUnderTest.submit_test.
+
+        Returns a TestRunItem representing the created simulation test run.
+        """
         # create or update driver if needed
         if isinstance(driver, Driver):
             driver_model = self.create_or_update_driver(driver)
@@ -1580,7 +1617,7 @@ class Okareo:
         project_id: Optional[str] = None,
         return_model_metrics: bool = False,
     ) -> list:
-        """Find test runs, optionally filtering by name or tags.
+        """Find existing test runs for simulation/evaluation workflows.
 
         Args:
             name: Filter results to runs with this exact name (client-side).
@@ -1673,6 +1710,21 @@ class Okareo:
         file_bytes: Optional[bytes] = None,
         project_id: Optional[str] = None,
     ) -> VoiceUploadResponse:
+        """Upload a voice file for use in voice scenarios/simulations.
+
+        Provide either a local `file_path` or in-memory `file_bytes`.
+
+        Args:
+            file_path: Path to a local audio file.
+            file_bytes: Raw audio bytes.
+            project_id: Optional project ID to associate with the uploaded file.
+
+        Returns:
+            VoiceUploadResponse: Metadata including a downloadable `file_url`.
+
+        Raises:
+            ValueError: If neither `file_path` nor `file_bytes` is provided.
+        """
         audio_data = None
         if file_bytes:
             audio_data = file_bytes


### PR DESCRIPTION
## Feature: Python SDK pydoc refresh — voice/simulation coverage + cleaner module surface

### Problem

1. **Published pydoc surface was misaligned** — pydoc config still included logger/callback modules while missing `augmentations`, so rendered reference coverage did not match current docs goals.
2. **Voice/simulation discoverability gaps** — key simulation and voice methods/classes lacked clear docstring coverage in generated docs.
3. **Generated markdown fragility** — JSON-like list bullets in generated markdown could break MDX parsing.
4. **Docstring parser artifacts** — some argument docs rendered as malformed numbered placeholders; method docs needed parser-safe formatting.

### Changes

#### 1. Scope pydoc modules to intended surface (`pyproject.toml`)
Updated `[tool.pydoc-markdown]` modules to:
- `okareo.model_under_test`
- `okareo.checks`
- `okareo.okareo`
- `okareo.augmentations`

Removed logger/callback/reporter modules from the pydoc module list.

#### 2. Update pydoc postprocess ordering + MDX safety (`docs/build_docs_postprocess.py`)
- Removed logger/callback pages from ordering/drop logic.
- Added `augmentations` into desired output ordering.
- Added sanitization helpers to convert JSON-like bullets (`- { ... }`) into code-literal bullets for MDX safety.

#### 3. Improve high-value `Okareo` docstrings (`src/okareo/okareo.py`)
Updated docs for simulation/voice surfaces:
- `create_or_update_driver`
- `get_driver_by_name`
- `create_or_update_target`
- `get_target_by_name`
- `run_simulation` (parser-safe parameter summary)
- `find_test_runs`
- `upload_voice`

Also normalized prose so generated docs avoid malformed parameter rendering artifacts.

#### 4. Improve simulation/voice class docstrings (`src/okareo/model_under_test.py`)
Enhanced docstrings for:
- `VoiceTarget`
- `TwilioVoiceTarget`
- `PhoneTarget`
- `Driver`
- `Target`
- `Simulation`

Also adjusted `StreamingConfig` / `TurnConfig` docstring wording to avoid parser artifacts in generated output.

### Files changed

| File | Change |
|---|---|
| `pyproject.toml` | Restricted pydoc module list; added `okareo.augmentations` |
| `docs/build_docs_postprocess.py` | Updated page ordering/scope; added JSON-bullet sanitization |
| `src/okareo/okareo.py` | Improved simulation/voice method docstrings; parser-safe run_simulation docs |
| `src/okareo/model_under_test.py` | Improved voice/simulation class docstrings; parser-safe streaming/turn docs |

### Production behavior changes

| Setting | Before | After | Impact |
|---|---|---|---|
| Pydoc module inclusion | Included logger/callback modules; omitted augmentations | Includes augmentations; excludes logger/callback modules | Rendered API reference better matches intended published surface |
| Generated markdown handling | No JSON-bullet sanitization in postprocess | JSON-like bullets converted to code-literals | Reduces MDX compile failures in rendered docs |

Net effect: generated Python reference now emphasizes the intended voice/simulation/augmentation SDK surfaces, with cleaner and more stable rendered docs.

### Deferred to follow-up

| Item | Reason |
|---|---|
| OpenAI/Deepgram voice target docstring expansion | Out of scope for this docs refresh; only maintained voice target classes were explicitly updated |
| CI pydoc coverage gate | Intentionally excluded to avoid deploy-coupling/blocking |
