### PR TITLE
test: drop retired predefined checks from tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Removed
+
+- References to retired predefined checks (`is_best_option`, `is_code_functional`,
+  `does_code_compile`, `contains_all_imports`), which are no longer available in
+  the Okareo platform.
+
 ## [0.0.133] - 2026-06-09
 
 ### Added

--- a/okareo_tests/test_integration_checks.py
+++ b/okareo_tests/test_integration_checks.py
@@ -121,8 +121,6 @@ def test_run_code_based_predefined_checks(
         "levenshtein_distance",
         "levenshtein_distance_input",
         "compression_ratio",
-        "does_code_compile",
-        "contains_all_imports",
         "corpus_BLEU",
         "latency",
         "is_json",

--- a/okareo_tests/test_run_errors.py
+++ b/okareo_tests/test_run_errors.py
@@ -658,7 +658,6 @@ class TestMultiturnErrors:
                 repeats=1,
                 stop_check={"check_name": "model_refusal", "stop_on": False},
                 checks=[
-                    "contains_all_imports",
                     "compression_ratio",
                     "are_all_params_expected",
                     "reverse_qa_quality",


### PR DESCRIPTION
The server retired four predefined checks (is_best_option, is_code_functional, does_code_compile, contains_all_imports). Integration tests that passed those names to run_test/run_simulation now fail against the updated server with "checks entered was invalid", which breaks the sdk-test-latest gate on the server's release pipeline.

Drop the retired names from the affected fixtures and document the removal in the changelog so SDK users referencing them are warned.

## Description

A short description about the changes in this pull request. If the pull request is related to some issue, mention it
 here.

## Checklist

- [ ] Tests covering the new functionality have been added
- [ ] Documentation has been updated OR the change is too minor to be documented
- [ ] Changes are listed in the `CHANGELOG.md` OR changes are insignificant
