### PR TITLE
Update voice dogfood tests for time_to_first_audio rename

### DIFF
--- a/okareo_tests/test_voice_augmentation_params.py
+++ b/okareo_tests/test_voice_augmentation_params.py
@@ -182,7 +182,7 @@ def run_and_verify_augmentation(
         first_turn="target",
         calculate_metrics=True,
         augmentation=aug_config,
-        checks=["avg_turn_taking_latency"],
+        checks=["time_to_first_audio"],
     )
 
     assert isinstance(

--- a/okareo_tests/test_voice_multiturn.py
+++ b/okareo_tests/test_voice_multiturn.py
@@ -271,7 +271,7 @@ def run_voice_multiturn_test_audio_check(
         repeats=1,
         first_turn="driver",
         checks=[
-            "avg_turn_taking_latency",
+            "time_to_first_audio",
             "avg_words_per_minute",
             "total_turn_count",
             "empathy_score",
@@ -381,7 +381,7 @@ def test_voice_multiturn_voice_profile(
         repeats=1,
         first_turn="driver",
         checks=[
-            "avg_turn_taking_latency",
+            "time_to_first_audio",
             "avg_words_per_minute",
             "total_turn_count",
         ],

--- a/okareo_tests/test_voice_simulation.py
+++ b/okareo_tests/test_voice_simulation.py
@@ -304,17 +304,20 @@ def validate_test_run_sanity(
         mean_scores = metrics.get("mean_scores", {})
         baseline = metrics.get("aggregate_baseline_metrics", {})
 
-        # Driver turn taking latency check
+        # Driver turn taking latency. aggregate_baseline_metrics is keyed by the
+        # internal metric key, which the check rename does not change.
         turn_taking_latency = baseline.get("avg_turn_taking_latency")
         assert (
             turn_taking_latency is not None
         ), "avg_turn_taking_latency should exist in baseline"
 
-        # Target turn taking latency exists
-        target_latency = mean_scores.get("avg_turn_taking_latency")
+        # Target turn taking latency exists. The check was renamed
+        # avg_turn_taking_latency -> time_to_first_audio, so mean_scores (keyed by
+        # check name) now reports it under the canonical name.
+        target_latency = mean_scores.get("time_to_first_audio")
         assert (
             target_latency is not None
-        ), "avg_turn_taking_latency should exist in mean_scores"
+        ), "time_to_first_audio should exist in mean_scores"
 
     # Get datapoints and messages
     all_datapoints = get_datapoints(okareo, evaluation.id)
@@ -481,7 +484,7 @@ class TestVoiceSanity:
             first_turn="driver",
             calculate_metrics=True,
             checks=[
-                "avg_turn_taking_latency",
+                "time_to_first_audio",
                 "avg_words_per_minute",
                 "total_turn_count",
             ],
@@ -531,7 +534,7 @@ class TestVoiceFirstTurn:
             first_turn="driver",
             calculate_metrics=True,
             checks=[
-                "avg_turn_taking_latency",
+                "time_to_first_audio",
                 "avg_words_per_minute",
                 "total_turn_count",
             ],
@@ -581,7 +584,7 @@ class TestVoiceFirstTurn:
             first_turn="target",
             calculate_metrics=True,
             checks=[
-                "avg_turn_taking_latency",
+                "time_to_first_audio",
                 "avg_words_per_minute",
                 "total_turn_count",
             ],


### PR DESCRIPTION
## Why

Backend okareo_server#930 renamed the predefined voice check `avg_turn_taking_latency` → `time_to_first_audio` (old name kept as an alias). `mean_scores` is keyed by the **check name**, so it now reports this metric under `time_to_first_audio`. The dogfood test asserted the old key and failed `sdk-test-latest` post-deploy (blocking green promotion).

## Changes

- `test_voice_simulation.py`: `mean_scores.get("time_to_first_audio")` (was `avg_turn_taking_latency`). `aggregate_baseline_metrics` is keyed by the internal **metric key** (unchanged by the rename), so that assertion keeps `avg_turn_taking_latency`.
- `test_voice_multiturn.py`, `test_voice_augmentation_params.py`: update `checks=[...]` inputs to the canonical name (the alias still resolves, but the SDK's own tests should use the current name).

Must be released to PyPI so the backend's `sdk-test-latest` job (installs latest published `okareo`) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)