### PR TITLE
refactor(checks): stop sending output type

### DIFF
--- a/okareo_tests/checks/code_check_no_type.py
+++ b/okareo_tests/checks/code_check_no_type.py
@@ -1,7 +1,0 @@
-from okareo.checks import CheckResponse, CodeBasedCheck
-
-
-class Check(CodeBasedCheck):
-    @staticmethod
-    def evaluate(model_output: str, scenario_input: str, scenario_result: str, metadata: dict, model_input: str) -> CheckResponse:  # fmt: skip
-        return CheckResponse(score=True, explanation="Always passes.")

--- a/okareo_tests/checks/code_check_pass_fail.py
+++ b/okareo_tests/checks/code_check_pass_fail.py
@@ -1,9 +1,7 @@
-from okareo.checks import CheckOutputType, CheckResponse, CodeBasedCheck
+from okareo.checks import CheckResponse, CodeBasedCheck
 
 
 class Check(CodeBasedCheck):
-    check_type = CheckOutputType.PASS_FAIL
-
     @staticmethod
     def evaluate(model_output: str, scenario_input: str, scenario_result: str, metadata: dict, model_input: str) -> CheckResponse:  # fmt: skip
         passed = len(model_output) > 0

--- a/okareo_tests/checks/code_check_score.py
+++ b/okareo_tests/checks/code_check_score.py
@@ -1,9 +1,7 @@
-from okareo.checks import CheckOutputType, CheckResponse, CodeBasedCheck
+from okareo.checks import CheckResponse, CodeBasedCheck
 
 
 class Check(CodeBasedCheck):
-    check_type = CheckOutputType.SCORE
-
     @staticmethod
     def evaluate(model_output: str, scenario_input: str, scenario_result: str, metadata: dict, model_input: str) -> CheckResponse:  # fmt: skip
         return CheckResponse(

--- a/okareo_tests/checks/sample_check_with_explanation.py
+++ b/okareo_tests/checks/sample_check_with_explanation.py
@@ -1,9 +1,7 @@
-from okareo.checks import CheckOutputType, CheckResponse, CodeBasedCheck
+from okareo.checks import CheckResponse, CodeBasedCheck
 
 
 class Check(CodeBasedCheck):
-    check_type = CheckOutputType.PASS_FAIL
-
     @staticmethod
     def evaluate(model_output: str, scenario_input: str, scenario_result: str, metadata: dict, model_input: str) -> CheckResponse:  # fmt: skip
         return (

--- a/okareo_tests/test_code_check_config.py
+++ b/okareo_tests/test_code_check_config.py
@@ -1,34 +1,33 @@
-"""Unit tests for CodeBasedCheck output-type resolution in check_config().
+"""Unit tests for CodeBasedCheck.check_config().
 
-These run without a live server: they call check.check_config() directly and
-assert the `type` value the SDK would send to the backend.
+These run without a live server. The SDK no longer declares an output type for
+code-based checks: check_config() emits only `code_contents`, and the server
+infers pass/fail vs. score from the check's runtime return value at persist time.
 """
 
-import pytest
 from okareo_tests.checks import (
-    code_check_no_type,
     code_check_pass_fail,
     code_check_score,
     sample_check,
 )
 
 
-def test_explicit_pass_fail_maps_to_pass_fail() -> None:
+def test_check_config_emits_code_contents_and_no_type() -> None:
     config = code_check_pass_fail.Check().check_config()
-    assert config["type"] == "pass_fail"
+    assert "code_contents" in config
+    assert "type" not in config
 
 
-def test_explicit_score_maps_to_score() -> None:
+def test_check_response_check_without_type_does_not_raise() -> None:
+    # A CheckResponse-returning check with no type declaration is valid now;
+    # the server infers the output type from the runtime value.
     config = code_check_score.Check().check_config()
-    assert config["type"] == "score"
+    assert "code_contents" in config
+    assert "type" not in config
 
 
-def test_primitive_bool_annotation_is_backward_compatible() -> None:
-    # No check_type declared; a `-> bool` return annotation still resolves to "bool".
+def test_primitive_annotation_check_emits_no_type() -> None:
+    # A `-> bool` check no longer sends a derived "type" either.
     config = sample_check.Check().check_config()
-    assert config["type"] == "bool"
-
-
-def test_check_response_without_check_type_raises() -> None:
-    with pytest.raises(ValueError):
-        code_check_no_type.Check().check_config()
+    assert "code_contents" in config
+    assert "type" not in config

--- a/src/okareo/checks.py
+++ b/src/okareo/checks.py
@@ -113,24 +113,15 @@ class CodeBasedCheck(BaseCheck):
     3. Implement the `evaluate` method in your Check class.
     4. Include any additional code used by your check in the same file.
 
-    Declare the output type with the `check_type` class attribute, using the same
-    `CheckOutputType` values as `ModelBasedCheck`:
-    - `CheckOutputType.PASS_FAIL` -> the check produces a boolean pass/fail result.
-    - `CheckOutputType.SCORE` -> the check produces a numeric score.
-
-    `check_type` is required whenever `evaluate` returns a `CheckResponse` or a tuple
-    (the return annotation alone cannot convey pass/fail vs. score intent). If `evaluate`
-    is annotated to return a bare `bool`, `int`, or `float`, the output type is inferred
-    from that annotation and `check_type` may be omitted.
+    The output type (pass/fail vs. score) is inferred by the server from the value
+    your `evaluate` method returns, so you do not need to declare it.
 
     Example:
     ```python
     # In my_custom_check.py
-    from okareo.checks import CheckOutputType, CodeBasedCheck, CheckResponse
+    from okareo.checks import CodeBasedCheck, CheckResponse
 
     class Check(CodeBasedCheck):
-        check_type = CheckOutputType.PASS_FAIL
-
         @staticmethod
         def evaluate(
             model_output: str, scenario_input: str, scenario_result: str, metadata: dict, model_input: str
@@ -149,8 +140,6 @@ class CodeBasedCheck(BaseCheck):
     ```
     """
 
-    check_type: Optional[CheckOutputType] = None
-
     def check_config(self) -> dict:
         module = inspect.getmodule(self)
         if module is None:
@@ -161,24 +150,4 @@ class CodeBasedCheck(BaseCheck):
             raise ValueError(
                 "Unable to read source code for check class. Please place the check class in a separate file."
             ) from e
-        return {"code_contents": source, "type": self._resolve_output_type()}
-
-    def _resolve_output_type(self) -> str:
-        """Resolve the check's output type for check_config().
-
-        Prefers the explicit `check_type` class attribute. Falls back to inferring a
-        primitive output type from the `evaluate` return annotation for backward
-        compatibility. Raises when neither is available (e.g. a `CheckResponse` or
-        tuple return with no `check_type` declared).
-        """
-        if isinstance(self.check_type, CheckOutputType):
-            return self.check_type.value
-        annotation = inspect.signature(self.evaluate).return_annotation
-        name = getattr(annotation, "__name__", None)
-        if name in ("bool", "int", "float"):
-            return str(name)
-        raise ValueError(
-            "CodeBasedCheck could not determine its output type. Set "
-            "`check_type = CheckOutputType.PASS_FAIL` (boolean pass/fail) or "
-            "`check_type = CheckOutputType.SCORE` (numeric score) on your Check class."
-        )
+        return {"code_contents": source}


### PR DESCRIPTION
## Why

`CodeBasedCheck.check_config()` derived the `type` it sent to the backend from
the `evaluate` return annotation, which couldn't convey pass/fail vs. score for
a `CheckResponse` return and forced users to hand-declare a `check_type`. The
backend now infers the output type from the check's runtime return value, so the
client no longer needs to resolve or send it.

## What changed

- `check_config()` emits only `code_contents`. Removed the `check_type`
  attribute, the annotation-based `_resolve_output_type`, and the `ValueError`
  it raised.
- Fixtures dropped `check_type`; `code_check_no_type.py` deleted; unit coverage
  updated to assert no `type` key and no raise. `ModelBasedCheck` is untouched.

## Coordinated change

Pairs with okareo_server PR https://github.com/okareo-ai/okareo_server/pull/941,
which infers and sets the type server-side. **The server change must ship
first** — a client without `type` against an old server would `KeyError`.

## Test plan

- `okareo_tests/test_code_check_config.py`: 3 passed.
- Verified end-to-end against a local server: a `bool` `CheckResponse` persists
  as `pass_fail`, an `int` `CheckResponse` persists as `score`.
