### PR TITLE
test(multiturn): expect custom-endpoint exception run to FAIL (total-wipeout) + bump 0.0.142

### DIFF
--- a/okareo_tests/test_integration_multiturn.py
+++ b/okareo_tests/test_integration_multiturn.py
@@ -34,7 +34,6 @@ from okareo.model_under_test import (
 from okareo_api_client.models.find_test_data_point_payload import (
     FindTestDataPointPayload,
 )
-from okareo_api_client.models.full_data_point_item import FullDataPointItem
 from okareo_api_client.models.scenario_set_create import ScenarioSetCreate
 from okareo_api_client.models.seed_data import SeedData
 
@@ -1205,34 +1204,27 @@ def test_multiturn_driver_with_custom_endpoint_exception(
     )
     scenario = okareo.create_scenario_set(scenario_set_create)
 
-    # Run the test; errors are now captured per-row in error_message
+    # Every row's custom-endpoint call fails auth (bad "foobar" key), so the
+    # whole run is a total-wipeout: the server marks it FAILED and the sync
+    # submit raises, surfacing the redacted representative error to the caller.
     redacted_str = "*" * 16
 
-    test_run = okareo.run_simulation(
-        target=target,
-        driver=driver,
-        name=f"Custom Endpoint Test Exception - {unique_suffix}",
-        api_key=API_KEY,
-        scenario=scenario,
-        stop_check=StopConfig(check_name="task_completed"),
-        max_turns=2,
-        first_turn="driver",
-        checks=["task_completed"],
-    )
+    with pytest.raises(Exception) as exc_info:
+        okareo.run_simulation(
+            target=target,
+            driver=driver,
+            name=f"Custom Endpoint Test Exception - {unique_suffix}",
+            api_key=API_KEY,
+            scenario=scenario,
+            stop_check=StopConfig(check_name="task_completed"),
+            max_turns=2,
+            first_turn="driver",
+            checks=["task_completed"],
+        )
 
-    # Fetch the test data points and verify error_message on each row
-    tdps = okareo.find_test_data_points(
-        FindTestDataPointPayload(test_run_id=test_run.id, full_data_point=True)
-    )
-    assert isinstance(tdps, list)
-    assert len(tdps) > 0
-
-    for tdp in tdps:
-        assert isinstance(tdp, FullDataPointItem)
-        assert tdp.error_message is not None, "error_message should be populated"
-        assert isinstance(tdp.error_message, str), "error_message should be a string"
-        assert "Invalid Okareo API Token" in tdp.error_message
-        assert redacted_str in tdp.error_message
+    error_str = str(exc_info.value)
+    assert "Invalid Okareo API Token" in error_str
+    assert redacted_str in error_str
 
 
 @pytest.mark.skip(reason="Skipping submit test for multiturn error")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "okareo"
-version = "0.0.141"
+version = "0.0.142"
 description = "Python SDK for interacting with Okareo Cloud APIs"
 authors = [
     "Okareo <info@okareo.com>",


### PR DESCRIPTION
## What
Update `test_multiturn_driver_with_custom_endpoint_exception` to expect the run to **FAIL/raise** (total-wipeout) instead of completing with per-row `error_message`, and bump the SDK version to `0.0.142` so the server release pipeline can reach the fix.

## Why
The test set up a custom endpoint with a bad key (`"foobar"`) so **every** row's call 401s, then asserted the run *completed* with each datapoint's `error_message` populated. But the server deliberately changed this in `d067bf30` ("total-wipeout — all rows errored — fails the run"): when every conversation errors, the run is marked `FAILED` and the sync submit raises the redacted representative error.

That made this test the **odd one out** — its sibling `test_run_errors.py::TestMultiturnErrors::test_custom_endpoint_status_code_mismatch` / `_sensitive_fields` already expect a **raise** (via `pytest.raises`) for the same all-rows-errored scenario, and those pass. This aligns the two.

## Change
- `run_simulation(...)` is now wrapped in `pytest.raises(Exception)`, asserting the error contains `"Invalid Okareo API Token"` and the 16-char redacted key.
- Removed the now-unused `FullDataPointItem` import.
- **No server change, no regression** to the tests that depend on the raise.

## Verification
Passes against a local server (`localhost:8000`): `run_simulation` raised on the all-errored custom endpoint; both assertions held.

🤖 Generated with [Claude Code](https://claude.com/claude-code)