### PR TITLE
fix(driver): keep temperature=0 when reading a driver from the API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 
+- `Driver.from_response` no longer discards `temperature=0`, which previously fell back
+  to the `0.6` default and was written back to the API on the next update.
 - Example code-based check fixtures now declare `check_type` explicitly, matching the
   output-type requirement for code-based checks (a check returning `CheckResponse`
   otherwise fails output-type inference).

--- a/okareo_tests/test_model_under_test.py
+++ b/okareo_tests/test_model_under_test.py
@@ -20,6 +20,7 @@ from okareo.model_under_test import (
     AuthConfig,
     CohereModel,
     CustomEndpointTarget,
+    Driver,
     EndSessionConfig,
     OpenAIModel,
     OpenAIVoiceTarget,
@@ -30,6 +31,7 @@ from okareo.model_under_test import (
     TwilioVoiceTarget,
 )
 from okareo_api_client.models import SeedData
+from okareo_api_client.models.driver_model_response import DriverModelResponse
 from okareo_api_client.models.scenario_set_create import ScenarioSetCreate
 from okareo_api_client.models.test_run_type import TestRunType
 
@@ -444,3 +446,33 @@ class TestCustomEndpointTargetParams:
     def test_type_is_custom_endpoint(self) -> None:
         target = CustomEndpointTarget(None, MINIMAL_TURN)
         assert target.params()["type"] == "custom_endpoint"
+
+
+# ---------------------------------------------------------------------------
+# Driver.from_response
+# ---------------------------------------------------------------------------
+def driver_model_response(temperature: float) -> DriverModelResponse:
+    return DriverModelResponse.from_dict(
+        {
+            "id": MOCK_UUID,
+            "name": "deterministic-driver",
+            "temperature": temperature,
+            "prompt_template": "{scenario_input}",
+            "time_created": datetime.now().isoformat(),
+        }
+    )
+
+
+def test_driver_from_response_keeps_zero_temperature() -> None:
+    """temperature=0 is a valid setting and must survive the round trip."""
+    driver = Driver.from_response(driver_model_response(0))
+
+    assert driver.temperature == 0
+    # to_dict() is what create_or_update_driver posts back to the API
+    assert driver.to_dict()["temperature"] == 0
+
+
+def test_driver_from_response_keeps_nonzero_temperature() -> None:
+    driver = Driver.from_response(driver_model_response(0.2))
+
+    assert driver.temperature == 0.2

--- a/src/okareo/model_under_test.py
+++ b/src/okareo/model_under_test.py
@@ -2103,7 +2103,7 @@ class Driver:
             self.prompt_template = response.prompt_template
         if response.model_id:
             self.model_id = response.model_id
-        if response.temperature:
+        if response.temperature is not None:
             self.temperature = response.temperature
         if response.time_created:
             self.time_created = response.time_created


### PR DESCRIPTION
## Description

`Driver._get_driver_fields` guards every field assignment with a truthiness check:

```python
if response.temperature:
    self.temperature = response.temperature
```

`DriverModelResponse.temperature` and `VoiceDriverModelResponse.temperature` are declared as required `float`, so this guard never protects against a missing value. The only value it can ever filter out is a legitimate `0`.

The result is that a driver registered with `temperature=0` comes back with `temperature=0.6` (the `Driver` class default):

```python
driver = okareo.create_or_update_driver(Driver(name="deterministic", temperature=0))
driver.temperature   # 0.6
```

`get_driver_by_name` returns the same wrong value. This is worse than a bad read, because `Driver.to_dict()` is exactly what `create_or_update_driver` posts back — so a get-then-save round trip silently rewrites the stored `0` to `0.6` on the server and the driver stops being deterministic. Nothing raises and nothing is logged.

`run_simulation` hits this path too: it calls `create_or_update_driver(driver)` for an inline `Driver`, so the returned object already has the wrong temperature.

The fix compares against `None` instead. I deliberately left `model_id` and `project_id` alone — those are genuinely `Optional`/`Unset` on the response models, so a truthiness check there is not hiding anything.

## Test

Added two cases to `okareo_tests/test_model_under_test.py`, next to the existing `Target`/`CustomEndpointTarget` serialization tests. They construct a `DriverModelResponse` directly, so no network or API key is needed.

On `main`, with the source change reverted and only the test applied:

```
$ pytest okareo_tests/test_model_under_test.py -k driver_from_response
collected 26 items / 24 deselected / 2 selected

okareo_tests/test_model_under_test.py::test_driver_from_response_keeps_zero_temperature FAILED [ 50%]
okareo_tests/test_model_under_test.py::test_driver_from_response_keeps_nonzero_temperature PASSED [100%]

==================================== FAILURES =====================================
_______________ test_driver_from_response_keeps_zero_temperature __________________

    def test_driver_from_response_keeps_zero_temperature() -> None:
        """temperature=0 is a valid setting and must survive the round trip."""
        driver = Driver.from_response(driver_model_response(0))

>       assert driver.temperature == 0
E       AssertionError: assert 0.6 == 0
E        +  where 0.6 = Driver(name='deterministic-driver', prompt_template='{scenario_input}', model_id=None, temperature=0.6, id=UUID('0156f5d7-4ac4-4568-9d44-24750aa08d1a'), time_created='2026-07-27T12:27:15.664124', project_id=None, voice_instructions=None, voice_profile=None, voice=None).temperature

okareo_tests/test_model_under_test.py:470: AssertionError
=================== 1 failed, 1 passed, 24 deselected in 0.22s ====================
```

With the fix both pass. The rest of `test_model_under_test.py` is unchanged: 17 passed before, 19 after, with the same 7 `@integration` tests failing in both runs because they need a live API host.

## Checklist

- [x] Tests covering the new functionality have been added
- [x] Documentation has been updated OR the change is too minor to be documented
- [x] Changes are listed in the `CHANGELOG.md` OR changes are insignificant
