### PR TITLE
fix(client): pass timeout through to the HTTP client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 
+- `Okareo(timeout=...)` and the `HTTPX_TIME_OUT` environment variable are now applied to
+  the underlying HTTP client. Both were accepted and then discarded, so every request ran
+  with no timeout. When neither is set, requests stay untimed as before.
 - Example code-based check fixtures now declare `check_type` explicitly, matching the
   output-type requirement for code-based checks (a check returning `CheckResponse`
   otherwise fails output-type inference).

--- a/okareo_tests/test_client.py
+++ b/okareo_tests/test_client.py
@@ -3,6 +3,7 @@ import uuid
 from datetime import datetime
 from uuid import UUID
 
+import httpx
 import pytest
 from okareo_tests.common import API_KEY, OkareoAPIhost, integration
 from pytest_httpx import HTTPXMock
@@ -20,8 +21,8 @@ def test_can_instantiate() -> None:
     Okareo(API_KEY)
 
 
-@pytest.fixture
-def okareo_client(httpx_mock: HTTPXMock) -> Okareo:
+def mock_projects_response(httpx_mock: HTTPXMock) -> None:
+    """Register the response Okareo.__init__ makes on instantiation."""
     httpx_mock.add_response(
         json=[
             {
@@ -34,6 +35,11 @@ def okareo_client(httpx_mock: HTTPXMock) -> Okareo:
         ],
         status_code=201,
     )
+
+
+@pytest.fixture
+def okareo_client(httpx_mock: HTTPXMock) -> Okareo:
+    mock_projects_response(httpx_mock)
     return Okareo("foo", "http://mocked.com")
 
 
@@ -160,3 +166,37 @@ def test_get_scenario_data_points(okareo_client: Okareo, httpx_mock: HTTPXMock) 
 def test_get_all_checks(okareo_client: Okareo, httpx_mock: HTTPXMock) -> None:
     httpx_mock.add_response(json={}, status_code=201)
     okareo_client.get_all_checks()
+
+
+def test_timeout_argument_reaches_the_httpx_client(
+    httpx_mock: HTTPXMock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("HTTPX_TIME_OUT", raising=False)
+    mock_projects_response(httpx_mock)
+
+    okareo = Okareo("foo", "http://mocked.com", timeout=7)
+
+    assert okareo.client.get_httpx_client().timeout == httpx.Timeout(7)
+
+
+def test_httpx_time_out_env_var_reaches_the_httpx_client(
+    httpx_mock: HTTPXMock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("HTTPX_TIME_OUT", "12")
+    mock_projects_response(httpx_mock)
+
+    okareo = Okareo("foo", "http://mocked.com")
+
+    assert okareo.client.get_httpx_client().timeout == httpx.Timeout(12)
+
+
+def test_unconfigured_timeout_leaves_requests_untimed(
+    httpx_mock: HTTPXMock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No timeout is imposed on callers who did not ask for one."""
+    monkeypatch.delenv("HTTPX_TIME_OUT", raising=False)
+    mock_projects_response(httpx_mock)
+
+    okareo = Okareo("foo", "http://mocked.com")
+
+    assert okareo.client.get_httpx_client().timeout == httpx.Timeout(None)

--- a/src/okareo/common.py
+++ b/src/okareo/common.py
@@ -1,4 +1,5 @@
 import os
+from typing import Optional
 
 DEFAULT_BASE_URL = "https://api.okareo.com"
 BASE_URL = os.environ.get("OKAREO_BASE_URL") or os.environ.get(
@@ -7,7 +8,22 @@ BASE_URL = os.environ.get("OKAREO_BASE_URL") or os.environ.get(
 
 DEFAULT_HTTPX_TIME_OUT = 30
 # being generous to support the longer generations
+# kept for backwards compatibility; use get_httpx_time_out() to read the setting
 HTTPX_TIME_OUT = float(os.environ.get("HTTPX_TIME_OUT", DEFAULT_HTTPX_TIME_OUT))
+
+
+def get_httpx_time_out() -> Optional[float]:
+    """Request timeout in seconds, or None to leave requests untimed.
+
+    HTTPX_TIME_OUT is applied only when it is actually set in the environment.
+    Requests have run untimed since the generated client was introduced, and
+    calls such as run_test can legitimately take many minutes, so
+    DEFAULT_HTTPX_TIME_OUT is not imposed on callers who never asked for it.
+    """
+    raw = os.environ.get("HTTPX_TIME_OUT")
+    if not raw:
+        return None
+    return float(raw)
 
 
 class NotJSONError(Exception):

--- a/src/okareo/okareo.py
+++ b/src/okareo/okareo.py
@@ -6,6 +6,7 @@ import warnings
 from typing import Any, Dict, List, Optional, TypedDict, Union, cast
 from uuid import UUID
 
+import httpx
 import pydantic
 from pydantic import BaseModel as PydanticBaseModel
 from tqdm import tqdm  # type: ignore
@@ -108,7 +109,7 @@ from okareo_api_client.models.voice_upload_request import VoiceUploadRequest
 from okareo_api_client.models.voice_upload_response import VoiceUploadResponse
 from okareo_api_client.types import UNSET, File, Unset
 
-from .common import BASE_URL, HTTPX_TIME_OUT
+from .common import BASE_URL, get_httpx_time_out
 from .model_under_test import BaseModel, ModelUnderTest
 
 CHECK_DEPRECATION_WARNING = (
@@ -149,12 +150,28 @@ class Okareo:
     """A class for interacting with Okareo API and for formatting request data."""
 
     def __init__(
-        self, api_key: str, base_path: str = BASE_URL, timeout: float = HTTPX_TIME_OUT  # type: ignore
+        self,
+        api_key: str,
+        base_path: str = BASE_URL,  # type: ignore
+        timeout: Optional[float] = None,
     ):
+        """
+        Args:
+            api_key (str): Okareo API key.
+            base_path (str): Base URL of the Okareo API.
+            timeout (Optional[float]): Request timeout in seconds applied to every
+                API call made through this instance. Falls back to the
+                HTTPX_TIME_OUT environment variable. When neither is set,
+                requests are not timed out.
+        """
         self.api_key = api_key
+        if timeout is None:
+            timeout = get_httpx_time_out()
         self.client = Client(
-            base_url=base_path, raise_on_unexpected_status=True
-        )  # otherwise everything except 201 and 422 is swallowed
+            base_url=base_path,
+            raise_on_unexpected_status=True,  # otherwise everything except 201 and 422 is swallowed
+            timeout=httpx.Timeout(timeout) if timeout is not None else None,
+        )
         response = get_all_projects_v0_projects_get.sync(
             client=self.client,
             api_key=self.api_key,


### PR DESCRIPTION
## Description

`Okareo.__init__` takes a `timeout` argument and never uses it:

```python
def __init__(
    self, api_key: str, base_path: str = BASE_URL, timeout: float = HTTPX_TIME_OUT
):
    self.api_key = api_key
    self.client = Client(base_url=base_path, raise_on_unexpected_status=True)
```

`Client._timeout` therefore stays at its `None` default, and `get_httpx_client()`
constructs `httpx.Client(timeout=None)`. Passing `None` explicitly is not the same as
leaving it out — it disables httpx's own 5 second default, so the SDK runs with
`Timeout(timeout=None)`: no connect, read, write or pool timeout at all. A connection
that hangs hangs forever rather than raising.

`HTTPX_TIME_OUT` is read in `src/okareo/common.py` and used only as the default value of
that unused parameter, so setting it does nothing either.

This is a regression from 2eca8db ("switch to openapi-python-client, rm pydantic
dependency, move pytest-httpx to dev deps"), which replaced

```python
self.httpx_handler = HTTPXHandler(
    api_key=self.api_key, base_path=base_path, timeout=timeout
)
```

with `self.client = Client(base_url=base_path)` and left `timeout` on the signature.

## The fix, and what it deliberately does not do

The plumbing is wired up so `timeout` and `HTTPX_TIME_OUT` do what they say. What I did
*not* do is start applying `DEFAULT_HTTPX_TIME_OUT = 30` to everyone, because that is a
policy decision that belongs to you, not to a bug fix. `run_test`, `run_simulation` and
similar calls can legitimately take many minutes, and turning on a 30 second timeout for
callers who never asked for one would break working code in a patch release.

So:

- `timeout` is now `Optional[float] = None`.
- If it is not passed, `get_httpx_time_out()` reads `HTTPX_TIME_OUT` from the environment
  and returns `None` when it is unset.
- If the result is `None`, `Client` is constructed exactly as it is today and requests
  stay untimed.

`HTTPX_TIME_OUT` and `DEFAULT_HTTPX_TIME_OUT` are left in `common.py` for backwards
compatibility. If you do want a shipped default, the change is a one-line edit to
`get_httpx_time_out()` — happy to make it here if you tell me what value you want, or to
split it out so this PR stays behaviour-preserving.

## Test

Three cases in `okareo_tests/test_client.py`, using the existing `pytest_httpx` mock. They
assert on `okareo.client.get_httpx_client().timeout`, so no live API is needed. The
existing inline projects-response mock was pulled out of the `okareo_client` fixture into
`mock_projects_response()` so the new tests can reuse it.

The third test (`test_unconfigured_timeout_leaves_requests_untimed`) passes both before
and after — it is there to pin the "no timeout unless asked for" behaviour so a default
cannot be introduced by accident.

On `main`, with the source change reverted and only the tests applied:

```
$ pytest okareo_tests/test_client.py -k "timeout or time_out or untimed" --no-cov
collected 13 items / 10 deselected / 3 selected

okareo_tests/test_client.py::test_timeout_argument_reaches_the_httpx_client FAILED [ 33%]
okareo_tests/test_client.py::test_httpx_time_out_env_var_reaches_the_httpx_client FAILED [ 66%]
okareo_tests/test_client.py::test_unconfigured_timeout_leaves_requests_untimed PASSED [100%]

================================== FAILURES ===================================
_______________ test_timeout_argument_reaches_the_httpx_client ________________

    def test_timeout_argument_reaches_the_httpx_client(
        httpx_mock: HTTPXMock, monkeypatch: pytest.MonkeyPatch
    ) -> None:
        monkeypatch.delenv("HTTPX_TIME_OUT", raising=False)
        mock_projects_response(httpx_mock)

        okareo = Okareo("foo", "http://mocked.com", timeout=7)

>       assert okareo.client.get_httpx_client().timeout == httpx.Timeout(7)
E       AssertionError: assert Timeout(timeout=None) == Timeout(timeout=7)
E        +  where Timeout(timeout=None) = <httpx.Client object at 0x00000257EA35F440>.timeout
E        +    where <httpx.Client object at 0x00000257EA35F440> = get_httpx_client()
E        +      where get_httpx_client = Client(raise_on_unexpected_status=True, _base_url='http://mocked.com', _cookies={}, _headers={}, _timeout=None, _verify_ssl=True, _follow_redirects=False, _httpx_args={}, _client=<httpx.Client object at 0x00000257EA35F440>, _async_client=None).get_httpx_client

okareo_tests\test_client.py:179: AssertionError
____________ test_httpx_time_out_env_var_reaches_the_httpx_client _____________

    def test_httpx_time_out_env_var_reaches_the_httpx_client(
        httpx_mock: HTTPXMock, monkeypatch: pytest.MonkeyPatch
    ) -> None:
        monkeypatch.setenv("HTTPX_TIME_OUT", "12")
        mock_projects_response(httpx_mock)

        okareo = Okareo("foo", "http://mocked.com")

>       assert okareo.client.get_httpx_client().timeout == httpx.Timeout(12)
E       AssertionError: assert Timeout(timeout=None) == Timeout(timeout=12)
E        +  where Timeout(timeout=None) = <httpx.Client object at 0x00000257EA35F950>.timeout

okareo_tests\test_client.py:190: AssertionError
=========================== short test summary info ===========================
FAILED okareo_tests/test_client.py::test_timeout_argument_reaches_the_httpx_client
FAILED okareo_tests/test_client.py::test_httpx_time_out_env_var_reaches_the_httpx_client
================= 2 failed, 1 passed, 10 deselected in 0.92s ==================
```

`Timeout(timeout=None)` is the bug in one line.

With the fix all three pass. Whole file: 8 passed on `main`, 11 passed after, with the
same 2 failures in both runs (`test_can_instantiate` and
`test_create_scenario_set[okareo_api1]`) because they need a live API token.

`black`, `isort`, `flake8` and `mypy` are clean on the touched files; `mypy` reports the
same 5 pre-existing `redundant-cast` errors in generated `src/okareo_api_client` code
before and after. `kacl-cli verify` passes.

Related but independent of #260, which fixes a different bug; neither depends on the
other and they can be merged in any order.

## Checklist

- [x] Tests covering the new functionality have been added
- [x] Documentation has been updated OR the change is too minor to be documented
- [x] Changes are listed in the `CHANGELOG.md` OR changes are insignificant
