### PR TITLE
refactor!: deprecate stop_check (accepted but inert)

### DIFF
--- a/okareo_tests/test_run_errors.py
+++ b/okareo_tests/test_run_errors.py
@@ -133,6 +133,44 @@ class TestMultiturnErrors:
                 target_mut = okareo.create_or_update_target(target)
                 driver_mut = okareo.create_or_update_driver(driver) if driver else None
 
+    def _register_and_expect_success(
+        self,
+        okareo: Any,
+        target_config: Any,
+        driver_config: Any = None,
+        run_config: Any = None,
+        run_test: bool = False,
+        basic_scenario: Any = None,
+        api_keys: Any = None,
+        checks: Any = None,
+        sensitive_fields: Optional[list[str]] = None,
+    ) -> Any:
+        """Register a model and run a simulation, expecting it to be accepted.
+
+        Mirror of ``_register_and_expect_error`` for the tolerant-backend cases
+        where a payload that used to be rejected is now accepted. Returns the
+        created test run item. LIVE — needs OKAREO_API_KEY and a server.
+        """
+        target = Target(**target_config)
+        driver = Driver(**driver_config) if driver_config else None
+        target_mut = okareo.create_or_update_target(target)
+        driver_mut = okareo.create_or_update_driver(driver) if driver else None
+
+        extra_run_config = {
+            "target": target_mut,
+            "driver": driver_mut,
+            "scenario": basic_scenario,
+            "api_keys": api_keys or self._create_basic_api_keys(),
+            "name": "Test Run",
+            "checks": checks or ["model_refusal"],
+            "sensitive_fields": sensitive_fields,
+        }
+        all_config = {**extra_run_config, **(run_config or {})}
+
+        result = okareo.run_simulation(**all_config)
+        assert result is not None
+        return result
+
     def test_missing_target(self, rnd: str, okareo: Any) -> None:
         """Test failure when target is missing"""
         target_config = {
@@ -204,7 +242,18 @@ class TestMultiturnErrors:
         )
 
     def test_empty_stop_check(self, rnd: str, okareo: Any, basic_scenario: Any) -> None:
-        """Test failure when no checks are provided"""
+        """stop_check is deprecated and inert: an empty stop_check config is now
+        accepted (not rejected) by the tolerant backend.
+
+        Requires tolerant backend; runs in CI. LIVE test — needs OKAREO_API_KEY
+        and a server, cannot run locally.
+
+        Previously this asserted the backend error "Invalid 'stop_check'
+        configuration". The backend no longer terminates on stop_check nor
+        validates it, so a well-formed-but-empty stop_check payload is accepted.
+        A well-formed (has check_name) stop_check dict does not raise client-side,
+        so the run is submitted and should succeed rather than error.
+        """
         run_config = {
             "max_turns": 2,
             "repeats": 1,
@@ -216,18 +265,26 @@ class TestMultiturnErrors:
             "name": f"Missing Checks {rnd}",
         }
 
-        self._register_and_expect_error(
+        # Tolerant backend: the stop_check payload is accepted, not rejected.
+        # Assert the run is created rather than expecting a validation error.
+        self._register_and_expect_success(
             okareo=okareo,
             target_config=target_config,
             run_config=run_config,
-            expected_error="Invalid 'stop_check' configuration",
             run_test=True,
             basic_scenario=basic_scenario,
             checks=[],  # Empty list of checks
         )
 
     def test_invalid_stop_check(self, rnd: str, okareo: Any) -> None:
-        """Test failure when stop_check is invalid"""
+        """A malformed stop_check dict is a caller bug and still raises a
+        client-side TypeError, even though stop_check is deprecated/inert.
+
+        Requires tolerant backend; runs in CI. LIVE test — needs OKAREO_API_KEY
+        and a server. This expectation is unchanged by the deprecation: a dict
+        missing ``check_name`` fails at ``StopConfig(**stop_check)`` in the SDK,
+        distinct from a valid-but-inert legacy stop_check.
+        """
         run_config = {
             "max_turns": 2,
             "repeats": 1,

--- a/okareo_tests/test_stop_check_deprecation.py
+++ b/okareo_tests/test_stop_check_deprecation.py
@@ -1,0 +1,41 @@
+"""Hermetic unit tests for the deprecated (inert) stop_check mechanism.
+
+stop_check is retired backend-side: it is still accepted and serialized by the
+SDK for backward compatibility, but no longer terminates a simulation early.
+These tests assert the SDK still serializes it exactly as before (no network,
+no server) and that a malformed dict remains a client-side TypeError.
+"""
+
+import pytest
+
+from okareo.model_under_test import Simulation, StopConfig
+
+
+class TestStopCheckDeprecation:
+    def test_simulation_to_dict_serializes_stop_check_dict(self) -> None:
+        sim = Simulation(stop_check={"check_name": "x", "stop_on": True})
+        # A dict stop_check is coerced to StopConfig in __attrs_post_init__ and
+        # serialized back via StopConfig.params() in to_dict().
+        assert sim.to_dict()["stop_check"] == {"check_name": "x", "stop_on": True}
+
+    def test_simulation_to_dict_serializes_stop_config_instance(self) -> None:
+        sim = Simulation(stop_check=StopConfig(check_name="x", stop_on=True))
+        assert sim.to_dict()["stop_check"] == {"check_name": "x", "stop_on": True}
+
+    def test_simulation_to_dict_none_stop_check(self) -> None:
+        sim = Simulation()
+        assert sim.to_dict()["stop_check"] is None
+
+    def test_stop_config_params_shape(self) -> None:
+        sc = StopConfig(check_name="x", stop_on=False)
+        assert sc.params() == {"check_name": "x", "stop_on": False}
+
+    def test_stop_config_default_stop_on_is_true(self) -> None:
+        sc = StopConfig(check_name="x")
+        assert sc.params() == {"check_name": "x", "stop_on": True}
+
+    def test_malformed_stop_check_dict_raises_type_error(self) -> None:
+        # A malformed dict (missing check_name) is a caller bug and still raises
+        # client-side, distinct from a valid-but-inert legacy stop_check.
+        with pytest.raises(TypeError):
+            Simulation(stop_check={"invalid_field": "model_refusal"})

--- a/src/okareo/model_under_test.py
+++ b/src/okareo/model_under_test.py
@@ -1727,6 +1727,16 @@ class StopConfig:
     """
     Configuration for stopping a multiturn conversation based on a specific check.
 
+    .. deprecated::
+        ``stop_check`` is deprecated and no longer terminates a simulation early.
+        The value is still accepted and serialized for backward compatibility, but
+        the backend now ignores it. To end a conversation early, instruct the Driver
+        in its persona prompt to use the ``end_conversation`` action.
+
+        Note: passing a *malformed* stop_check dict (e.g., missing ``check_name``)
+        still raises ``TypeError`` client-side. That is a caller bug and is distinct
+        from a valid, but now-inert, legacy stop_check.
+
     Arguments:
         check_name: Name of the check to use for stopping the conversation.
         stop_on: The check condition to stop the conversation.
@@ -2191,6 +2201,14 @@ class Simulation:
 
     Includes turn controls, stop conditions, and optional augmentation settings
     used by `Okareo.run_simulation(...)`.
+
+    .. deprecated::
+        ``stop_check`` is deprecated and no longer terminates a simulation early.
+        It is still accepted and serialized (backend now ignores the value). To end
+        a conversation early, instruct the Driver in its persona prompt to use the
+        ``end_conversation`` action. A malformed ``stop_check`` dict (missing
+        ``check_name``) still raises ``TypeError`` client-side — that is a caller
+        bug, distinct from a valid legacy stop_check.
     """
 
     stop_check: Union[StopConfig, dict, None] = None
@@ -2234,9 +2252,19 @@ class MultiTurnDriver(BaseModel):
     """
     A driver model for Okareo multiturn evaluation.
 
+    .. deprecated::
+        ``stop_check`` is deprecated and no longer terminates a simulation early.
+        It is still accepted and serialized (backend now ignores the value). To end
+        a conversation early, instruct the Driver in its persona prompt to use the
+        ``end_conversation`` action. A malformed ``stop_check`` dict (missing
+        ``check_name``) still raises ``TypeError`` client-side — that is a caller
+        bug, distinct from a valid legacy stop_check.
+
     Arguments:
         target: Target model under test to use in the multiturn evaluation.
-        stop_check: A valid StopConfig or a dict that can be converted to StopConfig.
+        stop_check: Deprecated and inert. A valid StopConfig or a dict that can be
+            converted to StopConfig. Accepted and serialized, but no longer stops a
+            conversation early (see the deprecation note above).
         driver_model_id: Model ID to use for the driver model (e.g., "gpt-4.1").
         driver_temperature: Parameter for controlling the randomness of the driver model's output.
         repeats: Number of times to run a conversation per scenario row. Defaults to 1.

--- a/src/okareo/okareo.py
+++ b/src/okareo/okareo.py
@@ -1476,7 +1476,13 @@ class Okareo:
         - ``target`` / ``driver``: Registered names or object definitions.
         - ``checks``: Optional checks to execute.
         - ``stop_check``, ``repeats``, ``max_turns``, ``first_turn``:
-          Turn-flow controls.
+          Turn-flow controls. **``stop_check`` is deprecated and no longer
+          terminates a simulation early** — it is still accepted and serialized,
+          but the backend now ignores the value. To end a conversation early,
+          instruct the Driver in its persona prompt to use the ``end_conversation``
+          action. A malformed ``stop_check`` dict (missing ``check_name``) still
+          raises ``TypeError`` client-side; that is a caller bug, distinct from a
+          valid legacy stop_check.
         - ``checks_at_every_turn``, ``concurrent_ask_probability``,
           ``turn_transition_time``: Runtime simulation controls.
         - ``augmentation``: Optional augmentation settings.


### PR DESCRIPTION
## Driver Actions — SDK (okareo-python-sdk)

Part of the 3-repo Driver Actions change. The backend retires the **stop-check** early-termination mechanism in favor of a Driver-invoked `end_conversation` action authored in the persona prompt.

### What & why
`stop_check` no longer terminates a simulation. To keep existing SDK code working, it stays **accepted and serialized but inert**:
- `StopConfig`, `Simulation.stop_check`, `MultiTurnDriver.stop_check`, and `run_simulation(stop_check=...)` are unchanged on the wire (the backend now ignores the value), with **deprecation notes** added to each.
- A **malformed** `stop_check` dict (missing `check_name`) still raises `TypeError` client-side via `StopConfig(**dict)` — a caller bug, distinct from a valid-but-inert legacy value; documented in the deprecation note.

**BREAKING:** `stop_check` no longer stops a simulation early. Author early termination by instructing the Driver in its persona prompt (the Driver now has an `end_conversation` action).

### Tests
- New hermetic `okareo_tests/test_stop_check_deprecation.py` (6 tests) — `to_dict()`/`params()` round-trip, no network.
- Live-integration expectations in `test_run_errors.py` updated to the tolerant backend behavior; these run in **CI** (need a server), not locally.

### Deploy order
Merge/deploy the **backend PR first** (it tolerantly ignores `stop_check`); this SDK change is compatible either way.

### Scope note
No new SDK authoring surface for driver actions — they're authored in the Driver persona prompt (no schema change). See `okareo-core-c/plans/driver-actions/` for requirements, plan, and audits.
