### PR TITLE
fix(sdk): apply run_simulation tags to the created test run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 
+- `run_simulation(..., tags=[...])` now applies the tags to the test run it creates.
+  They were previously accepted and silently discarded, so the run came back with
+  `tags: []` and was not findable via `find_test_runs(tags=[...])`.
+  `ModelUnderTest.run_test` / `submit_test` also accept `tags` now.
 - Example code-based check fixtures now declare `check_type` explicitly, matching the
   output-type requirement for code-based checks (a check returning `CheckResponse`
   otherwise fails output-type inference).

--- a/okareo_tests/test_run_simulation_tags.py
+++ b/okareo_tests/test_run_simulation_tags.py
@@ -1,0 +1,202 @@
+"""Hermetic unit tests for tag propagation from run_simulation to the test run.
+
+`Okareo.run_simulation(..., tags=[...])` must put those tags on the *test run*
+it creates, so the run is findable via `find_test_runs(tags=[...])` and filterable
+in the Okareo app. These tests mock the HTTP layer (no server, no network) and
+assert the tags land in the body of the POST that creates the test run.
+"""
+
+import json
+from datetime import datetime
+from typing import Any
+from uuid import UUID
+
+import pytest
+from pytest_httpx import HTTPXMock
+
+from okareo.model_under_test import OpenAIModel, Target
+from okareo.okareo import Okareo
+from okareo_api_client.models.scenario_set_response import ScenarioSetResponse
+from okareo_api_client.models.scenario_type import ScenarioType
+
+MOCK_UUID = "0156f5d7-4ac4-4568-9d44-24750aa08d1a"
+
+SIMULATION_TAGS = ["driver-hangup-validation", "bare", "voice"]
+
+OPENAI_TARGET_MODEL = {
+    "type": "openai",
+    "model_id": "gpt-4o-mini",
+    "temperature": 0,
+    "system_prompt_template": "Be helpful",
+}
+
+
+@pytest.fixture
+def okareo_client(httpx_mock: HTTPXMock) -> Okareo:
+    httpx_mock.add_response(
+        json=[
+            {
+                "id": MOCK_UUID,
+                "name": "Global",
+                "onboarding_status": "onboarding_status",
+                "tags": [],
+                "additional_properties": {},
+            }
+        ],
+        status_code=201,
+    )
+    return Okareo("foo", "http://mocked.com")
+
+
+def _add_driver_response(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_response(
+        json={
+            "id": MOCK_UUID,
+            "name": "driver",
+            "temperature": 0.6,
+            "model_id": "gpt-4o-mini",
+            "prompt_template": "{scenario_input}",
+            "time_created": datetime.now().isoformat(),
+        },
+        status_code=201,
+    )
+
+
+def _add_target_registration_response(httpx_mock: HTTPXMock) -> None:
+    """Response for POST /v0/register_model (target passed as a Target object)."""
+    httpx_mock.add_response(
+        json={
+            "id": MOCK_UUID,
+            "project_id": MOCK_UUID,
+            "name": "target",
+            "tags": SIMULATION_TAGS,
+            "time_created": datetime.now().isoformat(),
+            "version": 1,
+            "models": {"openai": OPENAI_TARGET_MODEL},
+        },
+        status_code=201,
+    )
+
+
+def _add_target_lookup_response(httpx_mock: HTTPXMock) -> None:
+    """Response for GET /v0/target/{name} (target passed as a string name)."""
+    httpx_mock.add_response(
+        json={
+            "id": MOCK_UUID,
+            "name": "target",
+            "target": OPENAI_TARGET_MODEL,
+        },
+        status_code=200,
+    )
+
+
+def _add_test_run_response(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_response(
+        json={
+            "id": MOCK_UUID,
+            "project_id": MOCK_UUID,
+            "mut_id": MOCK_UUID,
+            "scenario_set_id": MOCK_UUID,
+            "name": "tagged sim",
+            "type": "MULTI_TURN",
+            "tags": SIMULATION_TAGS,
+        },
+        status_code=201,
+    )
+
+
+def _scenario() -> ScenarioSetResponse:
+    return ScenarioSetResponse(
+        scenario_id=UUID(MOCK_UUID),
+        project_id=UUID(MOCK_UUID),
+        name="scenario",
+        time_created=datetime.now(),
+        type_=ScenarioType.SEED,
+    )
+
+
+def _test_run_request_body(httpx_mock: HTTPXMock) -> Any:
+    """Body of the POST that creates the test run (the last request made)."""
+    request = httpx_mock.get_requests()[-1]
+    assert request.url.path in ("/v0/test_run", "/v0/test_run/submit")
+    return json.loads(request.content.decode("utf-8"))
+
+
+def test_run_simulation_sends_tags_on_test_run_payload_for_target_object(
+    okareo_client: Okareo, httpx_mock: HTTPXMock
+) -> None:
+    _add_driver_response(httpx_mock)
+    _add_target_registration_response(httpx_mock)
+    _add_test_run_response(httpx_mock)
+
+    okareo_client.run_simulation(
+        name="tagged sim",
+        scenario=_scenario(),
+        target=Target(
+            name="target",
+            target=OpenAIModel(
+                model_id="gpt-4o-mini",
+                temperature=0,
+                system_prompt_template="Be helpful",
+            ),
+        ),
+        tags=SIMULATION_TAGS,
+    )
+
+    body = _test_run_request_body(httpx_mock)
+    assert body["tags"] == SIMULATION_TAGS
+
+
+def test_run_simulation_sends_tags_on_test_run_payload_for_target_by_name(
+    okareo_client: Okareo, httpx_mock: HTTPXMock
+) -> None:
+    """Tags must reach the test run even when the target is referenced by name."""
+    _add_driver_response(httpx_mock)
+    _add_target_lookup_response(httpx_mock)
+    _add_test_run_response(httpx_mock)
+
+    okareo_client.run_simulation(
+        name="tagged sim",
+        scenario=_scenario(),
+        target="target",
+        tags=SIMULATION_TAGS,
+    )
+
+    body = _test_run_request_body(httpx_mock)
+    assert body["tags"] == SIMULATION_TAGS
+
+
+def test_run_simulation_sends_tags_on_submit(
+    okareo_client: Okareo, httpx_mock: HTTPXMock
+) -> None:
+    _add_driver_response(httpx_mock)
+    _add_target_lookup_response(httpx_mock)
+    _add_test_run_response(httpx_mock)
+
+    okareo_client.run_simulation(
+        name="tagged sim",
+        scenario=_scenario(),
+        target="target",
+        tags=SIMULATION_TAGS,
+        submit=True,
+    )
+
+    body = _test_run_request_body(httpx_mock)
+    assert body["tags"] == SIMULATION_TAGS
+
+
+def test_run_simulation_without_tags_omits_tags_from_payload(
+    okareo_client: Okareo, httpx_mock: HTTPXMock
+) -> None:
+    _add_driver_response(httpx_mock)
+    _add_target_lookup_response(httpx_mock)
+    _add_test_run_response(httpx_mock)
+
+    okareo_client.run_simulation(
+        name="tagged sim",
+        scenario=_scenario(),
+        target="target",
+    )
+
+    body = _test_run_request_body(httpx_mock)
+    assert body.get("tags", []) == []

--- a/src/okareo/model_under_test.py
+++ b/src/okareo/model_under_test.py
@@ -378,6 +378,7 @@ class ModelUnderTest(AsyncProcessorMixin):
         simulation_params: Optional[Any],
         driver_id: Optional[str],
         nats_invoke_id: Optional[str],
+        tags: Optional[List[str]] = None,
     ) -> TestRunPayloadV2:
         serialized_simulation_params: Any = UNSET
         if simulation_params:
@@ -419,6 +420,7 @@ class ModelUnderTest(AsyncProcessorMixin):
                 else (driver_id if driver_id else UNSET)
             ),
             nats_invoke_id=nats_invoke_id if nats_invoke_id else UNSET,
+            tags=tags if tags else UNSET,
         )
 
     async def connect_nats(self, user_jwt: str, seed: str, local_nats: str) -> Any:
@@ -718,6 +720,7 @@ class ModelUnderTest(AsyncProcessorMixin):
         run_test_method: Any = None,
         simulation_params: Optional[Any] = None,
         driver_id: Optional[str] = None,
+        tags: Optional[List[str]] = None,
     ) -> TestRunItem:
         """Internal method to run a test. This method is used by both run_test and submit_test."""
         self.custom_model_thread: Any = None
@@ -780,6 +783,7 @@ class ModelUnderTest(AsyncProcessorMixin):
                         simulation_params,
                         driver_id,
                         None,
+                        tags,
                     )
                     assert isinstance(submit_response, TestRunItem)
                     test_run_id = submit_response.id
@@ -824,6 +828,7 @@ class ModelUnderTest(AsyncProcessorMixin):
                 simulation_params,
                 driver_id,
                 nats_invoke_id,
+                tags,
             )
 
             return response
@@ -851,6 +856,7 @@ class ModelUnderTest(AsyncProcessorMixin):
         simulation_params: Optional[Any],
         driver_id: Optional[str],
         nats_invoke_id: Optional[str],
+        tags: Optional[List[str]] = None,
     ) -> TestRunItem:
         response: TestRunItem = run_test_method(
             client=self.client,
@@ -869,6 +875,7 @@ class ModelUnderTest(AsyncProcessorMixin):
                 simulation_params,
                 driver_id,
                 nats_invoke_id,
+                tags,
             ),
         )
         if isinstance(response, ErrorResponse):
@@ -934,6 +941,7 @@ class ModelUnderTest(AsyncProcessorMixin):
         checks: Optional[List[str]] = None,
         simulation_params: Optional[Any] = None,
         driver_id: Optional[str] = None,
+        tags: Optional[List[str]] = None,
     ) -> TestRunItem:
         """Asynchronous server-based version of test-run execution. For CustomModels, model
         invocations are handled client-side in a background thread then evaluated server-side asynchronously.
@@ -948,6 +956,8 @@ class ModelUnderTest(AsyncProcessorMixin):
             test_run_type (TestRunType): The type of test run to execute. Defaults to MULTI_CLASS_CLASSIFICATION.
             calculate_metrics (bool): Whether to calculate metrics after the test run. Defaults to True.
             checks (Optional[List[str]]): Optional list of checks to perform during the test run.
+            tags (Optional[List[str]]): Optional tags to set on the created test run. These are
+                persisted on the test run itself and can be used with `Okareo.find_test_runs(tags=...)`.
 
         Returns:
             TestRunItem: The resulting test run item for the submitted test run. The `id` field can be used to retrieve the test run.
@@ -971,6 +981,7 @@ class ModelUnderTest(AsyncProcessorMixin):
             endpoint,
             simulation_params,
             driver_id,
+            tags,
         )
 
     def run_test(
@@ -985,6 +996,7 @@ class ModelUnderTest(AsyncProcessorMixin):
         checks: Optional[List[str]] = None,
         simulation_params: Optional[Any] = None,
         driver_id: Optional[str] = None,
+        tags: Optional[List[str]] = None,
     ) -> TestRunItem:
         """Server-based version of test-run execution. For CustomModels, model
         invocations are handled client-side then evaluated server-side. For other models,
@@ -999,6 +1011,8 @@ class ModelUnderTest(AsyncProcessorMixin):
             test_run_type (TestRunType): The type of test run to execute. Defaults to MULTI_CLASS_CLASSIFICATION.
             calculate_metrics (bool): Whether to calculate metrics after the test run. Defaults to True.
             checks (Optional[List[str]]): Optional list of checks to perform during the test run.
+            tags (Optional[List[str]]): Optional tags to set on the created test run. These are
+                persisted on the test run itself and can be used with `Okareo.find_test_runs(tags=...)`.
 
         Returns:
             TestRunItem: The resulting test run item for the completed test run.
@@ -1016,6 +1030,7 @@ class ModelUnderTest(AsyncProcessorMixin):
                 run_test_v0_test_run_post.sync,
                 simulation_params,
                 driver_id,
+                tags,
             )
         except Exception as e:
             raise TestRunError(str(e)) from e

--- a/src/okareo/okareo.py
+++ b/src/okareo/okareo.py
@@ -1482,8 +1482,14 @@ class Okareo:
         - ``augmentation``: Optional augmentation settings.
         - ``api_key`` / ``api_keys``: Provider credentials for target calls.
         - ``metrics_kwargs`` / ``calculate_metrics``: Metrics configuration.
-        - ``project_id`` / ``tags`` / ``sensitive_fields``: Registration and
-          metadata controls.
+        - ``project_id`` / ``sensitive_fields``: Registration controls.
+        - ``tags``: Tags applied to the **test run** this call creates — always,
+          regardless of how ``target`` is supplied. They are persisted on the run
+          and can be filtered on with ``Okareo.find_test_runs(tags=[...])``.
+          Additionally, when ``target`` is a ``Target`` **object** (which this call
+          registers or updates), the same tags are applied to that Target. When
+          ``target`` is a **string name**, the existing Target is looked up and its
+          tags are left untouched — only the test run is tagged.
         - ``submit``: If True, submit asynchronously via
           ModelUnderTest.submit_test.
 
@@ -1570,6 +1576,7 @@ class Okareo:
             checks=checks,
             simulation_params=simulation_params,
             driver_id=str(driver_model.id) if driver_model.id else None,
+            tags=tags,
         )
 
     def generate_driver_prompt(


### PR DESCRIPTION
## The bug

`Okareo.run_simulation(..., tags=[...])` accepts a `tags` argument and never applies it to the test run it creates. It fails silently — no error, no warning.

Inside `run_simulation` (`src/okareo/okareo.py`), `tags` was used in exactly two places, neither of them the test run:

1. `create_or_update_target(target, tags or [], ...)` — tags the **Target**, and only when `target` is a `Target` object.
2. `ModelUnderTestResponse(..., tags=tags or [], ...)` — a local `dummy_response` used only to construct a `ModelUnderTest`; never sent anywhere.

The call then ended in `mut.run_test(...)` / `mut.submit_test(...)` without `tags`. `ModelUnderTest._get_test_run_payload` built a `TestRunPayloadV2` that never set the `tags` field, so the POST body had no `tags` key at all.

Consequence: a simulation created with `tags=["driver-hangup-validation", "bare", "voice", ...]` comes back from `GET /v0/test_runs/{id}` with `tags: []` and is not findable via `find_test_runs(tags=[...])`.

## How it was verified

- **Failing test first (hermetic).** `okareo_tests/test_run_simulation_tags.py` mocks the HTTP layer with `pytest-httpx` and inspects the body of the POST that creates the test run. Before the fix, 3 of 4 tests failed with `KeyError: 'tags'` — the payload had no `tags` key. The 4th (no tags supplied → no tags sent) passed both before and after, as expected.
- **Payload/contract confirmed.** `TestRunPayloadV2` already has a `tags` field (`src/okareo_api_client/models/test_run_payload_v2.py`, and `openapi.json`). The backend schema has it too (`app/testruns/schema.py:274`, "Tags are strings that can be used to filter test runs in the Okareo app") and persists it — `app/services/testruns/test_run_service.py:1147` (`initialize_evaluation`) does `tags=payload.tags` — and `find_test_runs` filters on it (`app/services/testruns/test_run_request_service.py:499`).
- **Live backend, read-only.** Fetched `http://localhost:8000/openapi.json` and confirmed the running backend's `TestRunPayloadV2` exposes `tags`. No writes were made against it.

## The fix

The payload **does** support tags, so this is pure client-side threading — no follow-up `PUT /v0/test_runs/{id}` needed:

```
run_simulation -> run_test / submit_test -> _run_test_internal
  -> _call_run_test_method -> _get_test_run_payload -> TestRunPayloadV2(tags=...)
```

- `ModelUnderTest.run_test` and `ModelUnderTest.submit_test` gained an optional `tags: Optional[List[str]] = None` parameter (documented).
- `_get_test_run_payload` sets `tags=tags if tags else UNSET`, so the wire payload is byte-identical for callers that pass no tags.
- `run_simulation` passes `tags=tags` through to `run_test` / `submit_test`.
- New parameter is trailing and optional everywhere — no breaking change.

## Test added

`okareo_tests/test_run_simulation_tags.py` — hermetic, no server, no network. Chosen over an integration test because `okareo_tests/` integration tests need a live backend and a real `OKAREO_API_KEY`; this bug is entirely about what the SDK puts in the request body, which is fully observable with `pytest-httpx` (the same pattern as `okareo_tests/test_augmentations.py`).

Four cases:

| Test | Asserts |
|---|---|
| `..._for_target_object` | tags in POST body when `target` is a `Target` object |
| `..._for_target_by_name` | tags in POST body when `target` is a string name |
| `..._sends_tags_on_submit` | tags in POST body on the `submit=True` path (`/v0/test_run/submit`) |
| `..._without_tags_omits_tags_from_payload` | no `tags` key when caller passes none |

## `target`-by-name asymmetry (finding)

`tags` was doing double duty and behaving differently per call shape:

| `target` argument | Before | After |
|---|---|---|
| `Target` object | Target gets the tags; test run gets none | Target gets the tags **and** the test run gets the tags |
| string name | tags silently dropped entirely | test run gets the tags; existing Target untouched |

The test run is now tagged **unconditionally**, which is the consistent part and the thing callers actually asked for. Target tagging remains tied to the path that registers/updates the Target — a by-name reference deliberately does not mutate an existing (possibly shared) Target's tags as a side effect of running a simulation. This is now stated explicitly in the `run_simulation` docstring rather than being implicit.

## What I could not verify

- **No end-to-end run against a live backend.** Verification is hermetic plus a read-only openapi check against `localhost:8000`. Actually creating a simulation would mean writing a test run and burning provider model calls, so it was not done here. The backend-side persistence is confirmed by reading `test_run_service.initialize_evaluation`, not by observing a created run.
- **Full `pytest` is not green locally**, and was not green before this change either: `15 failed, 61 passed, 6 skipped, 191 errors`. Every failure/error is `TypeError: error: Invalid Okareo API Token` — `okareo_tests/` are integration tests against `api.okareo.com` and there is no `OKAREO_API_KEY` in this environment. All failures are on the `okareo_api1` (live host) parametrization. The hermetic subset passes: `16 passed` across `test_augmentations.py`, `test_stop_check_deprecation.py`, `test_run_simulation_tags.py`, `test_code_check_config.py` (plus one `test_model_invocation.py` error from the same missing API key).

## Lint

`black`, `isort`, `flake8` clean on the touched files; `mypy .` reports `Success: no issues found in 75 source files`; `kacl-cli verify` passes for the CHANGELOG entry.

## Base branch

**Targets `main`.** An earlier revision of this branch was stacked on `feat/driver-actions`; it was rebased off, and this fix is independent of the Driver-actions work — it stands alone and can merge in any order.
