### PR TITLE
test(voice): cover the Driver ending a call, without asserting that it did

### DIFF
--- a/okareo_tests/test_voice_simulation.py
+++ b/okareo_tests/test_voice_simulation.py
@@ -13,6 +13,7 @@ from uuid import UUID
 
 import pytest
 from okareo_tests.common import random_string
+from okareo_tests.utils import assert_valid_termination_reason, driver_authored
 
 from okareo import Okareo
 from okareo.model_under_test import Driver, Target, TwilioVoiceTarget
@@ -47,6 +48,7 @@ TARGET_WAITS_PROMPT = """
 ## Rules
 - Wait for the agent to greet you first.
 - Respond naturally to their greeting.
+- After the agent responds once, end the conversation.
 """.strip()
 
 
@@ -132,6 +134,31 @@ def get_messages(
                 messages_list.append(messages)
 
     return messages_list
+
+
+def get_termination_reasons(
+    okareo: Okareo, test_run_id: Union[str, UUID]
+) -> List[Union[str, None]]:
+    """Fetch why each conversation in a test run ended.
+
+    Same shape and ordering as ``get_messages`` -- one entry per datapoint -- so
+    the two can be read side by side.
+    """
+    from okareo_api_client.models.full_data_point_item import FullDataPointItem
+    from okareo_api_client.types import Unset
+
+    reasons: List[Union[str, None]] = []
+    for dp in get_datapoints(okareo, test_run_id):
+        if isinstance(dp, FullDataPointItem):
+            if (
+                not isinstance(dp.model_metadata, Unset)
+                and dp.model_metadata is not None
+            ):
+                reasons.append(
+                    dp.model_metadata.additional_properties.get("termination_reason")
+                )
+
+    return reasons
 
 
 def validate_message_timing(msg: Dict[str, Any], msg_idx: int) -> None:
@@ -579,7 +606,11 @@ class TestVoiceFirstTurn:
             target=Target(name=f"Twilio Target - {rnd}", target=twilio_target),
             name=f"Target Starts Test - {rnd}",
             scenario=scenario,
-            max_turns=2,
+            # 3, not 2: the Driver is told to end the call after one exchange, and
+            # two turns leaves no room to greet, exchange, and then end. Without
+            # the headroom the ending turn is never generated -- and that turn is
+            # the one the driver-latency assertions need to see.
+            max_turns=3,
             repeats=1,
             first_turn="target",
             calculate_metrics=True,
@@ -604,6 +635,22 @@ class TestVoiceFirstTurn:
         assert (
             first_msg.get("role") == "assistant"
         ), "First speaker should be target (assistant)"
+
+        # The Driver is prompted to end the call, which is what generates the
+        # ending turn and exposes it to the driver-latency ceiling above. That
+        # ending is deliberately NOT asserted: whether a live phone agent gives
+        # the Driver enough to finish on is not a property of our code, and
+        # requiring it would put a coin flip on the deploy gate.
+        reason = get_termination_reasons(okareo, evaluation.id)[0]
+        assert_valid_termination_reason(reason)
+
+        if driver_authored(reason):
+            # The Driver's goodbye is not the end of the conversation -- the reply
+            # to it is. Checked only when the Driver actually ended the call,
+            # since nobody owes a reply to a turn limit.
+            assert (
+                messages[-1].get("role") == "assistant"
+            ), f"Target should answer the Driver's closing line, got {messages[-1].get('role')!r}"
 
 
 class TestVoiceConcurrent:

--- a/okareo_tests/utils.py
+++ b/okareo_tests/utils.py
@@ -23,6 +23,67 @@ from okareo_api_client.models.test_data_point_item import TestDataPointItem
 from okareo_api_client.models.test_run_item import TestRunItem
 from okareo_api_client.types import Unset
 
+# ---------------------------------------------------------------- termination
+#
+# Why a conversation stopped, as written to
+# ``datapoint.model_metadata["termination_reason"]``.
+#
+# These are NOT an enum server-side. When the Driver ends a conversation itself
+# the value is the Driver's own prose, so there is no closed set to assert
+# membership in -- a "must be one of N" check would break the first time a model
+# phrased a goodbye differently. What CAN be asserted is that the field exists,
+# respects its write cap, and does not name a failure.
+
+# The backend writes these two only when something actually went wrong.
+FAILURE_REASONS = {
+    "Ended early after an error",
+    "Target disconnected before the conversation started",
+}
+
+# Every reason the backend writes for itself. Anything else is Driver-authored.
+# ``The Driver ended the conversation`` belongs here, not with the Driver's own
+# prose: it is the fallback written when the Driver ended the call but supplied
+# no usable reason, so there is no closing line to hold anyone to.
+HARNESS_WRITTEN_REASONS = FAILURE_REASONS | {
+    "Reached the turn limit",
+    "Target ended the call",
+    "The Driver ended the conversation",
+}
+
+# Hard cap applied server-side at write.
+MAX_TERMINATION_REASON_LENGTH = 200
+
+
+def driver_authored(reason: Union[str, None]) -> bool:
+    """True when the Driver wrote this termination reason itself.
+
+    Lets a test tell "the Driver ended it" from "something else did" WITHOUT
+    asserting that it must have. A Driver may legitimately not end a conversation
+    -- a tight turn budget, a Target that stalls -- and asserting otherwise puts a
+    coin flip on the deploy gate.
+
+    Stop-check reasons are matched by prefix because the backend interpolates the
+    Check's name into them.
+    """
+    if not reason or reason in HARNESS_WRITTEN_REASONS:
+        return False
+    return not reason.startswith("Stop condition met")
+
+
+def assert_valid_termination_reason(reason: Union[str, None]) -> None:
+    """Assert the conversation recorded a usable reason and did not die.
+
+    Passes for every legitimate ending: the turn limit, a stop check firing, the
+    Target hanging up, and any Driver-authored goodbye. Fails only on a genuine
+    failure, a missing reason, or one that broke its own cap.
+    """
+    assert reason, "termination_reason must be present on every conversation"
+    assert len(reason) <= MAX_TERMINATION_REASON_LENGTH, (
+        f"termination_reason exceeds the {MAX_TERMINATION_REASON_LENGTH}-char "
+        f"write cap: {len(reason)} chars"
+    )
+    assert reason not in FAILURE_REASONS, f"conversation ended in failure: {reason!r}"
+
 
 def assert_scores_geval(scores: dict) -> None:
     dimension_keys = [


### PR DESCRIPTION
**Draft — not for merge today.** Opened so CI actually runs: `test.yml` fires on `pull_request`, not on a branch push.

## Why

`sdk-test-latest` gates blue/green promotion, and the suite had **zero** references to `termination_reason`, `end_conversation`, or `closing_line`. The Driver's end-conversation feature could have broken entirely without failing a deploy.

## What this does

`test_target_starts_first` already asserts **every driver turn is under 7000ms** — stricter than any threshold we would have added, and exactly the shape that catches the ~13s of dead air the ending turn used to carry.

It just never saw an ending. Its Driver had no instruction to stop, so `end_conversation` was never called and the slow turn was never generated. **The fix is a prompt change plus turn headroom, not a new latency assertion.**

- `TARGET_WAITS_PROMPT` gains "After the agent responds once, end the conversation."
- `max_turns` 2 → 3, so there is room to greet, exchange, and end.
- `assert_valid_termination_reason()` on the result.
- FR11 (the Target answers the closing line), guarded.

## Deliberately absent: any assertion that the Driver ended the call

A Driver may legitimately not emit the tool call — a tight turn budget, a Target that stalls. Requiring it would put a coin flip on the promotion gate, measuring the callee's mood rather than our code.

The prompt still asks for the ending, so the path is exercised on most runs. The assertions only require that **whatever ending happened was well-formed**.

There is also no closed set of reasons to check membership in — a Driver-ended reason is the Driver's own prose. So the helper checks the three things true of every legitimate ending: present, within the 200-char write cap, and not naming a failure. Turn limit, stop check, Target hangup and any goodbye all pass; only genuine failure fails.

## Verified

- Helper logic exercised hermetically, 14 cases — no network.
- `pre-commit` (black, isort, mypy, flake8) clean on both files.
- 4 tests collect.

**Not verified locally: the voice test itself.** It places a real phone call and the Twilio secrets are not in the local environment. This PR is how it gets its first real run.

## Accepted gap

FR11 has no deterministic gate. Covering it properly needs a text simulation, and all 18 text multiturn tests set a `stop_check`, so none produces a Driver-ended conversation. It is checked opportunistically on voice only.

## Ordering

If these tests are ever published to PyPI, **okareo_server #986 must be live on blue first** — `sdk-test-latest` runs the *published* SDK's tests, so shipping these against a backend without the feature would fail every deploy.