### PR TITLE
feat(projects): scope a client to a Project, and manage Project lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,35 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+
+- Client-level Project (project separation): `Okareo(..., project=...)` and
+  `set_project()` scope every call without repeating `project_id`; precedence is
+  per-call / explicitly-set field, then client-level, then the server default.
+  Both accept a Project **name** or its id — `Okareo(api_key=KEY, project="Support Team")`
+  — since Project names are unique per organization. Names match case-insensitively
+  and ignore surrounding whitespace. A name or id that matches nothing fails at
+  construction with a message listing every available Project.
+- Project lifecycle: `get_project()`, `update_project()`, `archive_project()`,
+  `unarchive_project()`.
+  Archiving is reversible and only hides a Project from the picker — it restricts
+  nothing. The default ("Global") Project cannot be renamed or archived.
+- `create_project()` and `update_project()` reject a Project name with leading or
+  trailing whitespace locally, before the request — the same rule the server
+  applies, without the round trip.
+
+### Changed
+
+- Once the project-separation backend is deployed, search endpoints that
+  previously returned organization-wide results when `project_id` was omitted
+  (`find_datapoints`, `find_datapoints_filter`, `find_test_runs`, and voice
+  integration listing) resolve to the **default Project** instead. Every
+  organization currently has exactly one Project, so existing scripts see the
+  same data — but scripts that relied on omitted-project meaning "everything"
+  should pass an explicit `project_id` once they use multiple Projects.
+- `ingest_conversations` accepts an omitted `project_id` when a client-level
+  Project is set, and raises a clear error when neither is available.
+
 ### Removed
 
 - References to retired predefined checks (`is_best_option`, `is_code_functional`,

--- a/okareo_tests/common.py
+++ b/okareo_tests/common.py
@@ -31,3 +31,21 @@ def random_string(length: int) -> str:
 # if unavailable, mock a valid OpenAI API kley
 OPENAI_API_KEY = os.environ.get("OPENAI_API_KEY", f"sk-{random_string(48)}")
 OPENAI_MODEL = os.environ.get("OPENAI_MODEL", "gpt-4o-mini")
+
+
+def default_project_id(okareo_client: Any) -> str:
+    """The default ("Global") Project's id, selected BY NAME.
+
+    `GET /v0/projects` has no ORDER BY, so `get_projects()[0]` is arbitrary — and the
+    gate account accumulates Projects, so [0] is routinely not the default. Fails
+    loudly rather than falling back to [0]: a missing Global Project means default
+    resolution is broken org-wide and every downstream assertion would mislead.
+    """
+    projects = okareo_client.get_projects()
+    for project in projects:
+        if project.name == "Global":
+            return str(project.id)
+    raise AssertionError(
+        "No Project named 'Global' found — default-Project resolution is broken "
+        f"for this account. Projects: {[p.name for p in projects]}"
+    )

--- a/okareo_tests/test_checks.py
+++ b/okareo_tests/test_checks.py
@@ -1,6 +1,8 @@
+from uuid import UUID
+
 import pytest
 from okareo_tests.checks.sample_check import Check
-from okareo_tests.common import API_KEY, random_string
+from okareo_tests.common import API_KEY, default_project_id, random_string
 
 from okareo import Okareo
 from okareo_api_client.models import EvaluatorSpecRequest
@@ -26,7 +28,7 @@ def test_get_all_checks(okareo_client: Okareo) -> None:
 
 def test_generate_and_create_check(okareo_client: Okareo) -> None:
     generate_request = EvaluatorSpecRequest(
-        project_id=okareo_client.get_projects()[0].id,
+        project_id=UUID(default_project_id(okareo_client)),
         description="""
         Return True if the model_output is at least 20 characters long, otherwise return False.""",
         requires_scenario_input=False,

--- a/okareo_tests/test_client_project.py
+++ b/okareo_tests/test_client_project.py
@@ -1,0 +1,520 @@
+"""Unit tests for the client-level Project (project separation, Phase 7).
+
+Hermetic — every network call is mocked. Covers: validation at construction and in
+set_project; precedence (per-call / explicitly-set field → client-level → server
+default); fill-on-copy for caller-built payloads (UNSET only — an explicit None is
+an explicitly-set field and wins); Project name validation; and the lifecycle
+methods' parsers (the GET routes' 201, the hand-written PATCH module's 200).
+
+Precedence is asserted on the request a public method actually sends, never on the
+private resolver — a method that forgets to call the resolver has to fail here.
+"""
+
+import json
+import uuid
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+import httpx
+import pytest
+from pytest_httpx import HTTPXMock
+
+from okareo import Okareo
+from okareo_api_client.models.datapoint_filter_search_payload import (
+    DatapointFilterSearchPayload,
+)
+from okareo_api_client.models.datapoint_search import DatapointSearch
+from okareo_api_client.types import UNSET
+
+GLOBAL_ID = "0156f5d7-4ac4-4568-9d44-24750aa08d1a"
+OTHER_ID = "8a2b45f1-9c63-4b21-b7d8-1f2e3a4b5c6d"
+
+PROJECTS_JSON = [
+    {"id": GLOBAL_ID, "name": "Global", "onboarding_status": "s", "tags": []},
+    {"id": OTHER_ID, "name": "Billing Agent", "onboarding_status": "s", "tags": []},
+]
+
+MUT_JSON = {
+    "id": "3f2b9a1c-5d6e-4f80-9a1b-2c3d4e5f6a7b",
+    "project_id": GLOBAL_ID,
+    "name": "CI target",
+    "tags": [],
+    "time_created": "2024-01-01T00:00:00",
+}
+
+SCENARIO_JSON = {
+    "project_id": GLOBAL_ID,
+    "scenario_id": "6b1f0c2d-8e3a-4d5b-9c7e-1a2b3c4d5e6f",
+    "time_created": "2024-01-01T00:00:00",
+    "type": "SEED",
+}
+
+VOICE_JSON = {
+    "file_id": "9c8b7a6d-5e4f-4a3b-8c9d-0e1f2a3b4c5d",
+    "file_url": "https://example.com/audio.mp3",
+    "file_duration": 1000.0,
+    "time_created": "2024-01-01T00:00:00",
+}
+
+
+def _mock_projects(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_response(json=PROJECTS_JSON, status_code=201)
+
+
+def _sent_body(httpx_mock: HTTPXMock) -> Any:
+    """The JSON body of the last outgoing request."""
+    return json.loads(httpx_mock.get_requests()[-1].content)
+
+
+def _mock_upload(httpx_mock: HTTPXMock) -> Dict[str, bytes]:
+    """Answer the scenario-set upload, capturing the body it was sent.
+
+    A multipart body streams from an open file handle, so it can only be read
+    while the request is in flight — hence a callback rather than reading
+    ``get_requests()[-1].content`` afterwards.
+    """
+    captured: Dict[str, bytes] = {}
+
+    def respond(request: httpx.Request) -> httpx.Response:
+        captured["content"] = request.read()
+        return httpx.Response(200, json=SCENARIO_JSON)
+
+    httpx_mock.add_callback(respond, method="POST")
+    return captured
+
+
+def _multipart_project_id(content: bytes) -> Optional[str]:
+    """The ``project_id`` part of a multipart body, or None when it has none."""
+    body = content.decode()
+    marker = 'name="project_id"'
+    if marker not in body:
+        return None
+    return body.split(marker, 1)[1].split("\r\n\r\n", 1)[1].split("\r\n", 1)[0]
+
+
+def _scenario_file(tmp_path: Path) -> str:
+    path = tmp_path / "scenario.jsonl"
+    path.write_text('{"input": "hello", "result": "world"}\n')
+    return str(path)
+
+
+class TestConstructionValidation:
+    def test_valid_project_id_is_stored_normalized(self, httpx_mock: HTTPXMock) -> None:
+        _mock_projects(httpx_mock)
+        client = Okareo("k", "http://mocked.com", project=OTHER_ID.upper())
+        assert client.project_id == OTHER_ID  # normalized through UUID
+
+    def test_unknown_project_id_fails_loudly(self, httpx_mock: HTTPXMock) -> None:
+        _mock_projects(httpx_mock)
+        with pytest.raises(ValueError, match="Unknown project"):
+            Okareo("k", "http://mocked.com", project=str(uuid.uuid4()))
+
+    def test_no_project_keeps_server_default_semantics(
+        self, httpx_mock: HTTPXMock
+    ) -> None:
+        _mock_projects(httpx_mock)
+        client = Okareo("k", "http://mocked.com")
+        assert client.project_id is None
+
+
+class TestProjectByName:
+    """A Project may be named by its name as well as its id — names are unique
+    per organization (case-insensitively), so a name resolves to exactly one."""
+
+    def test_constructor_accepts_a_project_name(self, httpx_mock: HTTPXMock) -> None:
+        _mock_projects(httpx_mock)
+        client = Okareo("k", "http://mocked.com", project="Billing Agent")
+        assert client.project_id == OTHER_ID
+
+    def test_name_match_is_case_insensitive(self, httpx_mock: HTTPXMock) -> None:
+        _mock_projects(httpx_mock)
+        client = Okareo("k", "http://mocked.com", project="billing AGENT")
+        assert client.project_id == OTHER_ID
+
+    def test_surrounding_whitespace_is_ignored(self, httpx_mock: HTTPXMock) -> None:
+        _mock_projects(httpx_mock)
+        client = Okareo("k", "http://mocked.com", project="  Billing Agent  ")
+        assert client.project_id == OTHER_ID
+
+    def test_set_project_accepts_a_name(self, httpx_mock: HTTPXMock) -> None:
+        _mock_projects(httpx_mock)
+        client = Okareo("k", "http://mocked.com")
+        _mock_projects(httpx_mock)  # set_project fetches fresh
+        client.set_project("Billing Agent")
+        assert client.project_id == OTHER_ID
+
+    def test_unknown_name_names_every_available_project(
+        self, httpx_mock: HTTPXMock
+    ) -> None:
+        _mock_projects(httpx_mock)
+        with pytest.raises(ValueError) as exc:
+            Okareo("k", "http://mocked.com", project="Billing Team")
+        message = str(exc.value)
+        assert "Unknown project 'Billing Team'" in message
+        assert f"Global ({GLOBAL_ID})" in message
+        assert f"Billing Agent ({OTHER_ID})" in message
+
+    def test_a_name_is_never_mistaken_for_an_id(self, httpx_mock: HTTPXMock) -> None:
+        # An id that parses as a UUID but matches no Project must not fall
+        # through to a name lookup and quietly succeed.
+        _mock_projects(httpx_mock)
+        with pytest.raises(ValueError, match="Unknown project"):
+            Okareo("k", "http://mocked.com", project=str(uuid.uuid4()))
+
+
+class TestSetProject:
+    def test_set_project_validates_against_fresh_list(
+        self, httpx_mock: HTTPXMock
+    ) -> None:
+        _mock_projects(httpx_mock)
+        client = Okareo("k", "http://mocked.com")
+        _mock_projects(httpx_mock)  # set_project fetches fresh
+        client.set_project(OTHER_ID)
+        assert client.project_id == OTHER_ID
+
+    def test_set_project_none_clears(self, httpx_mock: HTTPXMock) -> None:
+        _mock_projects(httpx_mock)
+        client = Okareo("k", "http://mocked.com", project=GLOBAL_ID)
+        client.set_project(None)
+        assert client.project_id is None
+
+
+class TestPrecedence:
+    """Precedence — per-call > client-level > server default — proven through the
+    public methods, on the request each one actually sends. Asserting on the
+    helper instead would prove the helper works while proving nothing about
+    whether a method calls it."""
+
+    def test_per_call_project_wins_over_client_level(
+        self, httpx_mock: HTTPXMock
+    ) -> None:
+        _mock_projects(httpx_mock)
+        client = Okareo("k", "http://mocked.com", project=GLOBAL_ID)
+        httpx_mock.add_response(json=MUT_JSON, status_code=201)
+
+        client.register_model(name="CI target", project_id=OTHER_ID)
+
+        assert _sent_body(httpx_mock)["project_id"] == OTHER_ID
+
+    def test_client_level_project_fills_an_omitted_project_id(
+        self, httpx_mock: HTTPXMock
+    ) -> None:
+        _mock_projects(httpx_mock)
+        client = Okareo("k", "http://mocked.com", project=GLOBAL_ID)
+        httpx_mock.add_response(json=MUT_JSON, status_code=201)
+
+        client.register_model(name="CI target")
+
+        assert _sent_body(httpx_mock)["project_id"] == GLOBAL_ID
+
+    def test_no_project_anywhere_sends_no_project_id(
+        self, httpx_mock: HTTPXMock
+    ) -> None:
+        _mock_projects(httpx_mock)
+        client = Okareo("k", "http://mocked.com")
+        httpx_mock.add_response(json=MUT_JSON, status_code=201)
+
+        client.register_model(name="CI target")
+
+        assert "project_id" not in _sent_body(httpx_mock)
+
+    def test_find_test_runs_scopes_to_the_client_project(
+        self, httpx_mock: HTTPXMock
+    ) -> None:
+        _mock_projects(httpx_mock)
+        client = Okareo("k", "http://mocked.com", project=GLOBAL_ID)
+        httpx_mock.add_response(json=[], status_code=200)
+
+        client.find_test_runs()
+
+        assert _sent_body(httpx_mock)["project_id"] == GLOBAL_ID
+
+    def test_find_test_runs_per_call_project_wins(self, httpx_mock: HTTPXMock) -> None:
+        _mock_projects(httpx_mock)
+        client = Okareo("k", "http://mocked.com", project=GLOBAL_ID)
+        httpx_mock.add_response(json=[], status_code=200)
+
+        client.find_test_runs(project_id=OTHER_ID)
+
+        assert _sent_body(httpx_mock)["project_id"] == OTHER_ID
+
+    def test_upload_voice_scopes_to_the_client_project(
+        self, httpx_mock: HTTPXMock
+    ) -> None:
+        _mock_projects(httpx_mock)
+        client = Okareo("k", "http://mocked.com", project=OTHER_ID)
+        httpx_mock.add_response(json=VOICE_JSON, status_code=201)
+
+        client.upload_voice(file_bytes=b"audio-bytes")
+
+        assert _sent_body(httpx_mock)["project_id"] == OTHER_ID
+
+    def test_ingest_conversations_scopes_to_the_client_project(
+        self, httpx_mock: HTTPXMock
+    ) -> None:
+        _mock_projects(httpx_mock)
+        client = Okareo("k", "http://mocked.com", project=OTHER_ID)
+        httpx_mock.add_response(json={"status": "ok"}, status_code=200)
+
+        client.ingest_conversations(
+            conversations=[{"source_platform": "custom", "call_id": "c"}]
+        )
+
+        assert _sent_body(httpx_mock)["project_id"] == OTHER_ID
+
+
+class TestUploadScenarioSet:
+    """`upload_scenario_set` is Project-scoped like every other write, and its
+    Project travels in the multipart body."""
+
+    def test_upload_uses_the_client_project(
+        self, httpx_mock: HTTPXMock, tmp_path: Path
+    ) -> None:
+        _mock_projects(httpx_mock)
+        client = Okareo("k", "http://mocked.com", project=OTHER_ID)
+        sent = _mock_upload(httpx_mock)
+
+        client.upload_scenario_set(
+            scenario_name="CI upload", file_path=_scenario_file(tmp_path)
+        )
+
+        assert _multipart_project_id(sent["content"]) == OTHER_ID
+
+    def test_per_call_project_wins_over_client_project(
+        self, httpx_mock: HTTPXMock, tmp_path: Path
+    ) -> None:
+        _mock_projects(httpx_mock)
+        client = Okareo("k", "http://mocked.com", project=OTHER_ID)
+        sent = _mock_upload(httpx_mock)
+
+        client.upload_scenario_set(
+            scenario_name="CI upload",
+            file_path=_scenario_file(tmp_path),
+            project_id=GLOBAL_ID,
+        )
+
+        assert _multipart_project_id(sent["content"]) == GLOBAL_ID
+
+    def test_no_project_anywhere_sends_no_project_id(
+        self, httpx_mock: HTTPXMock, tmp_path: Path
+    ) -> None:
+        _mock_projects(httpx_mock)
+        client = Okareo("k", "http://mocked.com")
+        sent = _mock_upload(httpx_mock)
+
+        client.upload_scenario_set(
+            scenario_name="CI upload", file_path=_scenario_file(tmp_path)
+        )
+
+        assert _multipart_project_id(sent["content"]) is None
+
+
+class TestFillOnCopy:
+    def test_find_datapoints_body_gains_client_project(
+        self, httpx_mock: HTTPXMock
+    ) -> None:
+        _mock_projects(httpx_mock)
+        client = Okareo("k", "http://mocked.com", project=GLOBAL_ID)
+        httpx_mock.add_response(json=[], status_code=200)
+
+        search = DatapointSearch(context_token="tok")
+        client.find_datapoints(search)
+
+        sent = json.loads(httpx_mock.get_requests()[-1].content)
+        assert sent["project_id"] == GLOBAL_ID
+        # the caller's object is never mutated
+        assert isinstance(search.project_id, type(UNSET))
+
+    def test_find_datapoints_filter_body_gains_uuid_project(
+        self, httpx_mock: HTTPXMock
+    ) -> None:
+        _mock_projects(httpx_mock)
+        client = Okareo("k", "http://mocked.com", project=GLOBAL_ID)
+        httpx_mock.add_response(json=[], status_code=200)
+
+        client.find_datapoints_filter(DatapointFilterSearchPayload(filters=[]))
+
+        sent = json.loads(httpx_mock.get_requests()[-1].content)
+        assert sent["project_id"] == GLOBAL_ID
+
+    def test_explicitly_set_field_wins(self, httpx_mock: HTTPXMock) -> None:
+        _mock_projects(httpx_mock)
+        client = Okareo("k", "http://mocked.com", project=GLOBAL_ID)
+        httpx_mock.add_response(json=[], status_code=200)
+
+        client.find_datapoints(
+            DatapointSearch(context_token="tok", project_id=OTHER_ID)
+        )
+
+        sent = json.loads(httpx_mock.get_requests()[-1].content)
+        assert sent["project_id"] == OTHER_ID
+
+    def test_no_client_project_leaves_field_unset(self, httpx_mock: HTTPXMock) -> None:
+        _mock_projects(httpx_mock)
+        client = Okareo("k", "http://mocked.com")
+        httpx_mock.add_response(json=[], status_code=200)
+
+        client.find_datapoints(DatapointSearch(context_token="tok"))
+
+        sent = json.loads(httpx_mock.get_requests()[-1].content)
+        assert "project_id" not in sent
+
+
+class TestProjectLifecycle:
+    def test_get_project_fetches_one_by_id(self, httpx_mock: HTTPXMock) -> None:
+        _mock_projects(httpx_mock)
+        client = Okareo("k", "http://mocked.com")
+        httpx_mock.add_response(
+            json={
+                "id": OTHER_ID,
+                "name": "Billing Agent",
+                "onboarding_status": "s",
+                "tags": [],
+            },
+            # the GET routes answer 201 — the parser the SDK relies on
+            status_code=201,
+        )
+
+        project = client.get_project(OTHER_ID)
+
+        request = httpx_mock.get_requests()[-1]
+        assert request.method == "GET"
+        assert request.url.path == f"/v0/projects/{OTHER_ID}"
+        assert str(project.id) == OTHER_ID
+        assert project.name == "Billing Agent"
+
+    def test_archive_project_parses_200(self, httpx_mock: HTTPXMock) -> None:
+        # The hand-written PATCH module parses 200 (not the PUT/GET routes'
+        # SDK-load-bearing 201) — with raise_on_unexpected_status=True a wrong
+        # parser would raise on every success.
+        _mock_projects(httpx_mock)
+        client = Okareo("k", "http://mocked.com")
+        httpx_mock.add_response(
+            json={
+                "id": OTHER_ID,
+                "name": "Billing Agent",
+                "onboarding_status": "s",
+                "tags": [],
+                "is_archived": True,
+            },
+            status_code=200,
+        )
+
+        response = client.archive_project(OTHER_ID)
+
+        request = httpx_mock.get_requests()[-1]
+        assert request.method == "PATCH"
+        assert json.loads(request.content) == {"is_archived": True}
+        assert response.additional_properties["is_archived"] is True
+
+    def test_unarchive_project_sends_false(self, httpx_mock: HTTPXMock) -> None:
+        _mock_projects(httpx_mock)
+        client = Okareo("k", "http://mocked.com")
+        httpx_mock.add_response(
+            json={
+                "id": OTHER_ID,
+                "name": "Billing Agent",
+                "onboarding_status": "s",
+                "tags": [],
+                "is_archived": False,
+            },
+            status_code=200,
+        )
+
+        client.unarchive_project(OTHER_ID)
+
+        assert json.loads(httpx_mock.get_requests()[-1].content) == {
+            "is_archived": False
+        }
+
+    def test_update_project_sends_only_given_fields(
+        self, httpx_mock: HTTPXMock
+    ) -> None:
+        _mock_projects(httpx_mock)
+        client = Okareo("k", "http://mocked.com")
+        httpx_mock.add_response(
+            json={
+                "id": OTHER_ID,
+                "name": "Renamed",
+                "onboarding_status": "s",
+                "tags": [],
+            },
+            status_code=200,
+        )
+
+        client.update_project(OTHER_ID, name="Renamed")
+
+        assert json.loads(httpx_mock.get_requests()[-1].content) == {"name": "Renamed"}
+
+
+class TestProjectNameValidation:
+    """The server refuses a Project name with leading or trailing whitespace —
+    two Projects that look identical in the picker are distinct rows. The SDK
+    refuses it locally so the caller does not pay a round trip to find out."""
+
+    def test_create_project_refuses_surrounding_whitespace(
+        self, httpx_mock: HTTPXMock
+    ) -> None:
+        _mock_projects(httpx_mock)
+        client = Okareo("k", "http://mocked.com")
+
+        with pytest.raises(ValueError, match="whitespace"):
+            client.create_project(name=" Billing Agent ")
+
+        # nothing left the machine — only the construction-time projects fetch
+        assert len(httpx_mock.get_requests()) == 1
+
+    def test_update_project_refuses_surrounding_whitespace(
+        self, httpx_mock: HTTPXMock
+    ) -> None:
+        _mock_projects(httpx_mock)
+        client = Okareo("k", "http://mocked.com")
+
+        with pytest.raises(ValueError, match="whitespace"):
+            client.update_project(OTHER_ID, name="Billing Agent\n")
+
+        assert len(httpx_mock.get_requests()) == 1
+
+    def test_a_clean_name_is_sent_unchanged(self, httpx_mock: HTTPXMock) -> None:
+        _mock_projects(httpx_mock)
+        client = Okareo("k", "http://mocked.com")
+        httpx_mock.add_response(
+            json={
+                "id": OTHER_ID,
+                "name": "Billing Agent",
+                "onboarding_status": "s",
+                "tags": [],
+            },
+            status_code=201,
+        )
+
+        client.create_project(name="Billing Agent")
+
+        assert _sent_body(httpx_mock)["name"] == "Billing Agent"
+
+    def test_update_without_a_name_is_unaffected(self, httpx_mock: HTTPXMock) -> None:
+        _mock_projects(httpx_mock)
+        client = Okareo("k", "http://mocked.com")
+        httpx_mock.add_response(
+            json={
+                "id": OTHER_ID,
+                "name": "Billing Agent",
+                "onboarding_status": "s",
+                "tags": ["ops"],
+            },
+            status_code=200,
+        )
+
+        client.update_project(OTHER_ID, tags=["ops"])
+
+        assert _sent_body(httpx_mock) == {"tags": ["ops"]}
+
+
+class TestIngestConversationsGuard:
+    def test_requires_a_project_somewhere(self, httpx_mock: HTTPXMock) -> None:
+        _mock_projects(httpx_mock)
+        client = Okareo("k", "http://mocked.com")
+        with pytest.raises(ValueError, match="requires a project_id"):
+            client.ingest_conversations(
+                conversations=[{"source_platform": "custom", "call_id": "c"}]
+            )

--- a/okareo_tests/test_conversation_ingestion_e2e.py
+++ b/okareo_tests/test_conversation_ingestion_e2e.py
@@ -14,7 +14,7 @@ from collections.abc import Mapping
 from typing import Any, cast
 
 import pytest
-from okareo_tests.common import API_KEY, random_string
+from okareo_tests.common import API_KEY, default_project_id, random_string
 
 from okareo import Okareo
 from okareo_api_client.models.datapoint_list_item import DatapointListItem
@@ -36,8 +36,11 @@ def okareo_client() -> Okareo:
 @pytest.fixture(scope="module")
 def test_project(okareo_client: Okareo) -> str:
     """Get a test project for conversation ingestion tests."""
-    # For monitoring path, we just need a project - no MUT required
-    return str(okareo_client.get_projects()[0].id)
+    # For monitoring path, we just need a project - no MUT required. Select the
+    # default Project BY NAME: the read-back side of these tests queries without a
+    # project and resolves to the default, so ingesting into an arbitrary [0] puts
+    # the two sides of the assertion in different Projects.
+    return default_project_id(okareo_client)
 
 
 @pytest.fixture(scope="module")

--- a/okareo_tests/test_integration_checks.py
+++ b/okareo_tests/test_integration_checks.py
@@ -1,8 +1,9 @@
 import os
 from typing import Any, Union
+from uuid import UUID
 
 import pytest
-from okareo_tests.common import API_KEY, random_string
+from okareo_tests.common import API_KEY, default_project_id, random_string
 from okareo_tests.utils import assert_baseline_metrics, assert_metrics
 
 from okareo import Okareo
@@ -93,7 +94,7 @@ def test_generate_check(
     ]
     for check_dict in checks_to_generate:
         generate_request = EvaluatorSpecRequest(
-            project_id=okareo.get_projects()[0].id,
+            project_id=UUID(default_project_id(okareo)),
             description=str(check_dict["description"]),
             requires_scenario_input=bool(check_dict["requires_scenario_input"]),
             requires_scenario_result=bool(check_dict["requires_scenario_result"]),

--- a/okareo_tests/test_langchain.py
+++ b/okareo_tests/test_langchain.py
@@ -2,7 +2,6 @@ import random
 import string
 import uuid
 from datetime import datetime
-from unittest import mock
 
 from langchain.chains import LLMChain
 from langchain.llms.fake import FakeListLLM
@@ -51,10 +50,11 @@ def test_llm_generates_datapoints(
         )
         httpx_mock.add_response(json=get_mut_response(), status_code=201)
 
-    with mock.patch.object(Okareo.__init__, "__defaults__", (okareo_api.path, 100)):
-        handler = CallbackHandler(
-            mut_name="langchain_test", context_token=context_token
-        )
+    handler = CallbackHandler(
+        mut_name="langchain_test",
+        context_token=context_token,
+        base_path=okareo_api.path,
+    )
 
     llm = FakeListLLM(responses=["4"])
     llm.predict("what is 2+2?", callbacks=[handler])
@@ -85,8 +85,7 @@ def test_llm_auto_generate_model(
         )
         httpx_mock.add_response(json=get_mut_response(), status_code=201)
 
-    with mock.patch.object(Okareo.__init__, "__defaults__", (okareo_api.path, 100)):
-        handler = CallbackHandler(context_token=context_token)
+    handler = CallbackHandler(context_token=context_token, base_path=okareo_api.path)
 
     llm = FakeListLLM(responses=["4"])
     llm.predict("what is 2+2?", callbacks=[handler])
@@ -117,8 +116,7 @@ def test_chain_generates_datapoints(
         )
         httpx_mock.add_response(json=get_mut_response(), status_code=201)
 
-    with mock.patch.object(Okareo.__init__, "__defaults__", (okareo_api.path, 100)):
-        handler = CallbackHandler(context_token=context_token)
+    handler = CallbackHandler(context_token=context_token, base_path=okareo_api.path)
 
     llm = FakeListLLM(responses=["4"])
     prompt = PromptTemplate.from_template("what is 2+{number}?")

--- a/okareo_tests/test_litellm_logger.py
+++ b/okareo_tests/test_litellm_logger.py
@@ -1,7 +1,6 @@
 import time
 import uuid
 from datetime import datetime
-from unittest import mock
 
 import litellm  # type: ignore
 from litellm import completion
@@ -32,12 +31,12 @@ def dtest_litellm_baselogger(httpx_mock: HTTPXMock, okareo_api: OkareoAPIhost) -
     if okareo_api.is_mock:
         httpx_mock.add_response(json=get_mut_response(), status_code=201)
 
-    with mock.patch.object(Okareo.__init__, "__defaults__", (okareo_api.path, 100)):
-        handler = LiteLLMLogger(
-            api_key=API_KEY,
-            mut_name="test_litellm_baselogger-" + context_token,
-            context_token=context_token,
-        )
+    handler = LiteLLMLogger(
+        api_key=API_KEY,
+        mut_name="test_litellm_baselogger-" + context_token,
+        context_token=context_token,
+        host_address=okareo_api.path,
+    )
 
     litellm.callbacks = [handler]  # type: ignore
     model = "gpt-3.5-turbo"
@@ -68,12 +67,12 @@ def dtest_litellm_openailogger(
     if okareo_api.is_mock:
         httpx_mock.add_response(json=get_mut_response(), status_code=201)
 
-    with mock.patch.object(Okareo.__init__, "__defaults__", (okareo_api.path, 100)):
-        handler = LiteLLMProxyLogger(
-            api_key=API_KEY,
-            mut_name="test_litellm_openailogger-" + context_token,
-            context_token=context_token,
-        )
+    handler = LiteLLMProxyLogger(
+        api_key=API_KEY,
+        mut_name="test_litellm_openailogger-" + context_token,
+        context_token=context_token,
+        host_address=okareo_api.path,
+    )
 
     litellm.callbacks = [handler]  # type: ignore
     model = "gpt-3.5-turbo"

--- a/okareo_tests/test_projects.py
+++ b/okareo_tests/test_projects.py
@@ -7,7 +7,11 @@ import pytest
 from okareo_tests.common import API_KEY, random_string
 
 from okareo import Okareo
+from okareo.checks import CheckOutputType, ModelBasedCheck
 from okareo.model_under_test import CustomModel, ModelInvocation
+from okareo_api_client.api.default import (
+    get_all_models_under_test_v0_models_under_test_get,
+)
 from okareo_api_client.models import SeedData
 from okareo_api_client.models.project_response import ProjectResponse
 from okareo_api_client.models.scenario_set_create import ScenarioSetCreate
@@ -26,6 +30,45 @@ def okareo_client() -> Okareo:
     return Okareo(api_key=API_KEY)
 
 
+def scratch_project(okareo_client: Okareo, name: str) -> ProjectResponse:
+    """A fixed scratch Project, created only the first time it is needed.
+
+    Projects cannot be deleted and their names are unique per organization, so a
+    test that mints a new Project every run both piles them up in the gate
+    account (the condition `common.default_project_id` exists to work around)
+    and, with a fixed name, fails with a 400 on its second run.
+    """
+    existing = next(
+        (item for item in okareo_client.get_projects() if item.name == name), None
+    )
+    if existing:
+        return existing
+    return okareo_client.create_project(name=name)
+
+
+@pytest.fixture(scope="module")
+def project_a(okareo_client: Okareo) -> ProjectResponse:
+    return scratch_project(okareo_client, "CI - cross-project A")
+
+
+@pytest.fixture(scope="module")
+def project_b(okareo_client: Okareo) -> ProjectResponse:
+    return scratch_project(okareo_client, "CI - cross-project B")
+
+
+def target_names_in_project(
+    okareo_client: Okareo, project_id: Union[str, UUID]
+) -> List[str]:
+    """The names of the Targets (models under test) visible in one Project."""
+    response = get_all_models_under_test_v0_models_under_test_get.sync(
+        client=okareo_client.client,
+        api_key=API_KEY,
+        project_id=UUID(str(project_id)),
+    )
+    assert isinstance(response, list)
+    return [str(target.name) for target in response]
+
+
 def test_get_projects(okareo_client: Okareo) -> None:
     projects = okareo_client.get_projects()
     assert projects
@@ -35,15 +78,19 @@ def test_get_projects(okareo_client: Okareo) -> None:
     assert projects[0].name
 
 
-def test_create_project(okareo_client: Okareo) -> None:
-    project = okareo_client.create_project(
-        name="CI - Test P_Name", tags=["testT1", "testT2"]
-    )
+def test_create_project(rnd: str, okareo_client: Okareo) -> None:
+    # A fresh name every run: Project names are unique per organization and a
+    # Project cannot be deleted, so a fixed name is a 400 on the second run.
+    name = f"CI - Test P_Name {rnd}"
+    project = okareo_client.create_project(name=name, tags=["testT1", "testT2"])
     assert project
     assert isinstance(project, ProjectResponse)
     assert project.id
-    assert project.name == "CI - Test P_Name"
+    assert project.name == name
     assert project.tags == ["testT1", "testT2"]
+
+    # keep the picker clean — archiving is the only cleanup a Project has
+    okareo_client.archive_project(project.id)
 
 
 def test_full_eval_cycle_in_new_project(rnd: str, okareo_client: Okareo) -> None:
@@ -122,3 +169,97 @@ def assert_valid_test_run(
     assert test_run_item.model_metrics
     assert test_run_item.model_metrics.additional_properties.get("scores_by_label")
     assert test_run_item.project_id == project_id
+
+
+# --- Cross-Project semantics (project separation, Phase 7) -------------------
+#
+# These run against a live backend and assert the isolation guarantees, so they
+# are meaningful exactly where they run against the project-separation backend:
+# the backend's post-deploy `sdk-test-latest` job. They reuse fixed scratch
+# Projects (see `scratch_project`) rather than minting new ones per run.
+
+
+def test_isolated_type_not_visible_across_projects(
+    rnd: str,
+    okareo_client: Okareo,
+    project_a: ProjectResponse,
+    project_b: ProjectResponse,
+) -> None:
+    # G7: an isolated type — a Target — belongs to exactly one Project.
+    target_name = f"CI iso target {rnd}"
+    okareo_client.register_model(name=target_name, project_id=str(project_a.id))
+
+    # the control: the same listing DOES show it from its own Project, so the
+    # absence below is isolation and not an empty result
+    assert target_name in target_names_in_project(okareo_client, project_a.id)
+    assert target_name not in target_names_in_project(okareo_client, project_b.id)
+
+
+def test_shared_types_visible_from_any_project(
+    rnd: str, okareo_client: Okareo, project_a: ProjectResponse
+) -> None:
+    check_name = f"ci_shared_check_{rnd}".lower()
+    okareo_client.set_project(str(project_a.id))
+    try:
+        okareo_client.create_or_update_check(
+            name=check_name,
+            description="shared-type visibility check",
+            check=ModelBasedCheck(
+                prompt_template="Only output True",
+                check_type=CheckOutputType.PASS_FAIL,
+            ),
+        )
+    finally:
+        okareo_client.set_project(None)
+
+    # visible with no Project context (default) — shared org-wide
+    names = [c.name for c in okareo_client.get_all_checks()]
+    assert check_name in names
+
+
+def test_omitted_project_resolves_to_default(okareo_client: Okareo) -> None:
+    # The compatibility guarantee: no client-level Project, no per-call value —
+    # results are the DEFAULT Project's, not org-wide.
+    default_id = next(
+        str(p.id) for p in okareo_client.get_projects() if p.name == "Global"
+    )
+    runs = okareo_client.find_test_runs()
+    assert all(r.get("project_id") == default_id for r in runs if r.get("project_id"))
+
+
+def test_client_level_project_applies_and_per_call_overrides(
+    okareo_client: Okareo, project_a: ProjectResponse
+) -> None:
+    default_id = next(
+        str(p.id) for p in okareo_client.get_projects() if p.name == "Global"
+    )
+    okareo_client.set_project(str(project_a.id))
+    try:
+        runs_client_level = okareo_client.find_test_runs()
+        assert all(
+            r.get("project_id") == str(project_a.id)
+            for r in runs_client_level
+            if r.get("project_id")
+        )
+        runs_override = okareo_client.find_test_runs(project_id=default_id)
+        assert all(
+            r.get("project_id") == default_id
+            for r in runs_override
+            if r.get("project_id")
+        )
+    finally:
+        okareo_client.set_project(None)
+
+
+def test_archive_round_trip(okareo_client: Okareo) -> None:
+    # Works against any backend with Phase 4 deployed; independent of scoping.
+    # Its own scratch Project, since it leaves the Project archived.
+    project = scratch_project(okareo_client, "CI - archive round trip")
+
+    archived = okareo_client.archive_project(project.id)
+    assert archived.additional_properties.get("is_archived") is True
+
+    unarchived = okareo_client.unarchive_project(project.id)
+    assert unarchived.additional_properties.get("is_archived") is False
+
+    okareo_client.archive_project(project.id)  # leave the scratch project archived

--- a/okareo_tests/test_traces.py
+++ b/okareo_tests/test_traces.py
@@ -116,9 +116,10 @@ def find_datapoints(
     headers = {"Content-Type": "application/json", "api-key": api_key}
 
     with timed("GET /v0/projects"):
-        project_id = requests.get(f"{base_url}/v0/projects", headers=headers).json()[0][
-            "id"
-        ]
+        # Select the default Project by name — list order is arbitrary, and the
+        # ingestion this verifies lands in the default Project.
+        projects = requests.get(f"{base_url}/v0/projects", headers=headers).json()
+        project_id = next(p["id"] for p in projects if p["name"] == "Global")
 
     for attempt in range(3):
         with timed("POST /v0/find_datapoints_filter"):

--- a/src/okareo/callbacks.py
+++ b/src/okareo/callbacks.py
@@ -22,9 +22,18 @@ class CallbackHandler(BaseCallbackHandler):
         api_key: Optional[str] = None,
         mut_name: Optional[str] = None,
         context_token: Optional[str] = None,
+        base_path: Optional[str] = None,
     ) -> None:
-        """Initialize callback handler."""
-        self.okareo = Okareo(api_key or os.environ["OKAREO_API_KEY"])
+        """Initialize callback handler.
+
+        Args:
+            api_key: Okareo API key. Defaults to ``$OKAREO_API_KEY``.
+            mut_name: Name of the model to register datapoints against.
+            context_token: Token that ties the datapoints of one run together.
+            base_path: Okareo API base URL. Defaults to the SDK's own default.
+        """
+        key = api_key or os.environ["OKAREO_API_KEY"]
+        self.okareo = Okareo(key, base_path) if base_path else Okareo(key)
         self.inputs: List[Dict[str, Any]] = []
         self.context_token = context_token or "".join(
             random.choices(string.ascii_letters, k=10)

--- a/src/okareo/okareo.py
+++ b/src/okareo/okareo.py
@@ -1,9 +1,10 @@
 import base64
+import copy
 import datetime
 import json
 import os
 import warnings
-from typing import Any, Dict, List, Optional, TypedDict, Union, cast
+from typing import Any, Dict, List, Optional, Protocol, TypedDict, TypeVar, Union, cast
 from uuid import UUID
 
 import pydantic
@@ -33,8 +34,10 @@ from okareo_api_client.api.default import (
     get_datapoints_v0_find_datapoints_post,
     get_driver_v0_driver_identifier_get,
     get_model_under_test_by_name_and_version_v0_models_under_test_name_version_get,
+    get_project_v0_projects_project_id_get,
     get_scenario_set_data_points_v0_scenario_data_points_scenario_id_get,
     get_target_model_by_name_v0_target_target_model_name_get,
+    patch_project_v0_projects_project_id_patch,
     re_evaluate_v0_test_runs_test_run_id_re_evaluate_post,
     register_driver_model_v0_driver_post,
     register_model_v0_register_model_post,
@@ -83,6 +86,7 @@ from okareo_api_client.models.model_under_test_response_models_type_0 import (
     ModelUnderTestResponseModelsType0,
 )
 from okareo_api_client.models.model_under_test_schema import ModelUnderTestSchema
+from okareo_api_client.models.project_patch_schema import ProjectPatchSchema
 from okareo_api_client.models.project_response import ProjectResponse
 from okareo_api_client.models.project_schema import ProjectSchema
 from okareo_api_client.models.re_evaluate_payload import ReEvaluatePayload
@@ -123,6 +127,19 @@ _EMPTY_GENERATION_MESSAGE = "No scenario rows generated for scenario_id"
 CUSTOM_MODEL_STRS = ["custom", "custom_batch"]
 
 
+class ProjectScopedPayload(Protocol):
+    """Any generated request body that carries a ``project_id`` field."""
+
+    project_id: Any
+
+
+# The two Project helpers are type-preserving: what a caller hands in is the shape
+# it gets back. Typing them with these instead of `Any` keeps mypy checking every
+# call site that reassigns a typed variable from them.
+PayloadT = TypeVar("PayloadT", bound=ProjectScopedPayload)
+ProjectIdT = TypeVar("ProjectIdT", bound=Union[str, UUID, Unset, None])
+
+
 def check_deprecation_warning() -> None:
     warnings.warn(CHECK_DEPRECATION_WARNING, DeprecationWarning, stacklevel=2)
 
@@ -149,8 +166,21 @@ class Okareo:
     """A class for interacting with Okareo API and for formatting request data."""
 
     def __init__(
-        self, api_key: str, base_path: str = BASE_URL, timeout: float = HTTPX_TIME_OUT  # type: ignore
+        self,
+        api_key: str,
+        base_path: str = BASE_URL,  # type: ignore
+        timeout: float = HTTPX_TIME_OUT,
+        project: Union[str, UUID, None] = None,
     ):
+        """
+        Args:
+            api_key: Your Okareo API key.
+            base_path: Okareo API base URL.
+            timeout: HTTP timeout in seconds.
+            project: The Project this client works in — its **name** or its id.
+                Omit to keep the server's default Project (the pre-Projects
+                behavior). Resolved and validated here, at construction.
+        """
         self.api_key = api_key
         self.client = Client(
             base_url=base_path, raise_on_unexpected_status=True
@@ -160,6 +190,97 @@ class Okareo:
             api_key=self.api_key,
         )
         self.validate_response(response)
+        # Client-level Project (G5): applied wherever a per-call value is not given.
+        # Precedence everywhere: per-call / explicitly-set field > client-level >
+        # server default. Resolved against the projects list the connectivity
+        # check just fetched, so a bad name or id fails HERE with a clear message
+        # instead of silently scattering data — and a name costs no extra call.
+        # Archived Projects resolve on purpose — they stay fully usable.
+        self.project_id: Optional[str] = None
+        if project is not None:
+            assert isinstance(response, list)
+            self.project_id = self._resolve_project(project, response)
+
+    def set_project(self, project: Union[str, UUID, None]) -> None:
+        """Switch the client-level Project mid-script by name or id (None clears it).
+
+        Fetches a fresh Project list to resolve against — freshness over the cost
+        of one extra call on an infrequent operation.
+        """
+        if project is None:
+            self.project_id = None
+            return
+        self.project_id = self._resolve_project(project, self.get_projects())
+
+    @staticmethod
+    def _resolve_project(
+        project: Union[str, UUID], projects: List[ProjectResponse]
+    ) -> str:
+        """Resolve a Project name or id to its id.
+
+        A value that parses as a UUID is matched as an id and never falls back to
+        a name lookup — so a wrong id fails rather than quietly matching something
+        else. Anything else is matched as a name, case-insensitively and ignoring
+        surrounding whitespace; Project names are unique per organization, so a
+        name identifies exactly one Project.
+        """
+        value = str(project).strip()
+        try:
+            wanted_id: Optional[UUID] = UUID(value)
+        except ValueError:
+            wanted_id = None
+
+        for candidate in projects:
+            if wanted_id is not None:
+                if UUID(str(candidate.id)) == wanted_id:
+                    return str(wanted_id)
+            elif str(candidate.name).strip().casefold() == value.casefold():
+                return str(UUID(str(candidate.id)))
+
+        names = ", ".join(f"{p.name} ({p.id})" for p in projects)
+        raise ValueError(f"Unknown project {value!r}. Available Projects: {names}")
+
+    @staticmethod
+    def _validate_project_name(name: str) -> None:
+        """Reject a Project name the server would reject, before the round trip.
+
+        Leading or trailing whitespace is not part of a name — it makes two
+        Projects look identical in the picker while being distinct rows, so the
+        server refuses it. Catch it here so the caller gets a local error.
+        """
+        if name != name.strip():
+            raise ValueError(
+                f"Project name {name!r} has leading or trailing whitespace. "
+                f"Use {name.strip()!r} instead."
+            )
+
+    def _resolved_project_id(self, per_call: ProjectIdT) -> Union[ProjectIdT, str]:
+        """Per-call value when given; else the client-level Project; else the
+        caller's own unset sentinel (None or UNSET), which the server resolves to
+        the default Project.
+
+        The return type is the caller's own type widened only by ``str`` (the
+        client-level id), so each call site stays type-checked.
+        """
+        if per_call is not None and not isinstance(per_call, Unset):
+            return per_call
+        if self.project_id is not None:
+            return self.project_id
+        return per_call
+
+    def _with_client_project(
+        self, payload: PayloadT, as_uuid: bool = False
+    ) -> PayloadT:
+        """Return ``payload``, or a copy with ``project_id`` filled from the
+        client level when the field is UNSET (an explicitly-set field — including
+        an explicit None — wins). The caller's object is never mutated."""
+        if self.project_id is None:
+            return payload
+        if not isinstance(payload.project_id, Unset):
+            return payload
+        filled = copy.copy(payload)
+        filled.project_id = UUID(self.project_id) if as_uuid else self.project_id
+        return filled
 
     @staticmethod
     def seed_data_from_list(data_list: List[SeedDataRow]) -> List[SeedData]:
@@ -219,8 +340,10 @@ class Okareo:
 
         Raises:
             TypeError: If the API response is an error.
-            ValueError: If no response is received from the API.
+            ValueError: If the name has leading or trailing whitespace, or if no
+                response is received from the API.
         """
+        self._validate_project_name(name)
         response = create_project_v0_projects_post.sync(
             client=self.client,
             api_key=self.api_key,
@@ -229,6 +352,100 @@ class Okareo:
         self.validate_response(response)
         assert isinstance(response, ProjectResponse)
 
+        return response
+
+    def get_project(self, project_id: Union[str, UUID]) -> ProjectResponse:
+        """
+        Get a single project by id.
+
+        Args:
+            project_id (Union[str, UUID]): The ID of the project to fetch.
+
+        Returns:
+            ProjectResponse: The requested project.
+
+        Raises:
+            TypeError: If the API response is an error.
+            ValueError: If no response is received from the API.
+        """
+        response = get_project_v0_projects_project_id_get.sync(
+            project_id=UUID(str(project_id)),
+            client=self.client,
+            api_key=self.api_key,
+        )
+        self.validate_response(response)
+        assert isinstance(response, ProjectResponse)
+
+        return response
+
+    def update_project(
+        self,
+        project_id: Union[str, UUID],
+        name: Union[Unset, str] = UNSET,
+        tags: Union[Unset, List[str]] = UNSET,
+    ) -> ProjectResponse:
+        """
+        Update a project's name and/or tags. Only the fields you pass are changed.
+
+        Args:
+            project_id (Union[str, UUID]): The ID of the project to update.
+            name (Union[Unset, str], optional): New name for the project.
+            tags (Union[Unset, List[str]], optional): Replacement tag list.
+
+        Returns:
+            ProjectResponse: The updated project.
+
+        Raises:
+            ValueError: If the name has leading or trailing whitespace.
+        """
+        if not isinstance(name, Unset):
+            self._validate_project_name(name)
+        response = patch_project_v0_projects_project_id_patch.sync(
+            project_id=UUID(str(project_id)),
+            client=self.client,
+            api_key=self.api_key,
+            body=ProjectPatchSchema(name=name, tags=tags),
+        )
+        self.validate_response(response)
+        assert isinstance(response, ProjectResponse)
+        return response
+
+    def archive_project(self, project_id: Union[str, UUID]) -> ProjectResponse:
+        """
+        Archive a project. Archiving is reversible and restricts nothing — an
+        archived project stays fully usable; it is only hidden from the project
+        picker. The default ("Global") project cannot be archived.
+
+        Note: until the generated client is regenerated, the returned
+        ProjectResponse carries the archive state in
+        ``additional_properties["is_archived"]``.
+        """
+        response = patch_project_v0_projects_project_id_patch.sync(
+            project_id=UUID(str(project_id)),
+            client=self.client,
+            api_key=self.api_key,
+            body=ProjectPatchSchema(is_archived=True),
+        )
+        self.validate_response(response)
+        assert isinstance(response, ProjectResponse)
+        return response
+
+    def unarchive_project(self, project_id: Union[str, UUID]) -> ProjectResponse:
+        """
+        Unarchive a project, restoring it to the project picker.
+
+        Note: until the generated client is regenerated, the returned
+        ProjectResponse carries the archive state in
+        ``additional_properties["is_archived"]``.
+        """
+        response = patch_project_v0_projects_project_id_patch.sync(
+            project_id=UUID(str(project_id)),
+            client=self.client,
+            api_key=self.api_key,
+            body=ProjectPatchSchema(is_archived=False),
+        )
+        self.validate_response(response)
+        assert isinstance(response, ProjectResponse)
         return response
 
     def _get_custom_model_invoker(
@@ -294,6 +511,7 @@ class Okareo:
             TypeError: If the API response is an error.
             ValueError: If no response is received from the API.
         """
+        project_id = self._resolved_project_id(project_id)
         if tags is None:
             tags = []
         data: Dict[str, Any] = {
@@ -405,6 +623,7 @@ class Okareo:
         if create_request.seed_data == [] or create_request.seed_data is None:
             raise ValueError("Non-empty seed data is required to create a scenario set")
 
+        create_request = self._with_client_project(create_request, as_uuid=True)
         response = create_scenario_set_v0_scenario_sets_post.sync(
             client=self.client, api_key=self.api_key, body=create_request
         )
@@ -447,6 +666,7 @@ class Okareo:
         )
         ```
         """
+        project_id = self._resolved_project_id(project_id)
         try:
             file_name = os.path.basename(file_path)
 
@@ -560,6 +780,7 @@ class Okareo:
         print(generated_set.app_link) # Prints the link to the generated scenario set
         ```
         """
+        project_id = self._resolved_project_id(project_id)
         scenario_id = (
             source_scenario.scenario_id
             if isinstance(source_scenario, ScenarioSetResponse)
@@ -616,6 +837,7 @@ class Okareo:
                 )
             )
 
+        create_request = self._with_client_project(create_request, as_uuid=True)
         response = generate_scenario_set_v0_scenario_sets_generate_post.sync(
             client=self.client, api_key=self.api_key, body=create_request
         )
@@ -792,6 +1014,7 @@ class Okareo:
             print(dp)
         ```
         """
+        datapoint_search = self._with_client_project(datapoint_search)
         data = get_datapoints_v0_find_datapoints_post.sync(
             client=self.client,
             api_key=self.api_key,
@@ -848,6 +1071,7 @@ class Okareo:
             print(dp)
         ```
         """
+        datapoint_search = self._with_client_project(datapoint_search, as_uuid=True)
         data = get_datapoints_filter_v0_find_datapoints_filter_post.sync(
             client=self.client,
             api_key=self.api_key,
@@ -1166,6 +1390,9 @@ class Okareo:
         body = CheckCreateUpdateSchema(
             name=name, description=description, check_config=check_config
         )
+        # Provenance: Checks are shared org-wide, but the column records where the
+        # Check was authored — fill it from the client-level Project when set.
+        body = self._with_client_project(body, as_uuid=True)
         if tags is not None:
             body["tags"] = tags
         response = check_create_or_update_v0_check_create_or_update_post.sync(
@@ -1301,6 +1528,9 @@ class Okareo:
                 f"Invalid driver_temperature value: {driver.temperature}. Must be a number."
             ) from e
         request_body = DriverModelSchema.from_dict(driver.to_dict())
+        # Provenance: Drivers are shared org-wide; the column records authorship.
+        # Fill the wire schema, not the Driver — Driver.to_dict() drops project_id.
+        request_body = self._with_client_project(request_body, as_uuid=True)
         response = register_driver_model_v0_driver_post.sync(
             client=self.client,
             body=request_body,
@@ -1391,6 +1621,7 @@ class Okareo:
             session_starter,
             session_ender,
         ) = self._get_custom_model_invoker(data)
+        project_id = self._resolved_project_id(project_id)
         if project_id is not None:
             data["project_id"] = project_id
         request_body = ModelUnderTestSchema.from_dict(data)
@@ -1489,6 +1720,7 @@ class Okareo:
 
         Returns a TestRunItem representing the created simulation test run.
         """
+        project_id = self._resolved_project_id(project_id)
         # create or update driver if needed
         if isinstance(driver, Driver):
             driver_model = self.create_or_update_driver(driver)
@@ -1628,6 +1860,7 @@ class Okareo:
         Returns:
             List of test run dicts from the server.
         """
+        project_id = self._resolved_project_id(project_id)
         body: Dict[str, Any] = {"return_model_metrics": return_model_metrics}
         if tags:
             body["tags"] = tags
@@ -1735,6 +1968,7 @@ class Okareo:
             raise ValueError("Either file_path or file_bytes must be provided.")
         audio_b64 = base64.b64encode(audio_data).decode("utf-8")
 
+        project_id = self._resolved_project_id(project_id)
         payload = {"audio": audio_b64}
         if project_id:
             payload["project_id"] = project_id
@@ -1800,6 +2034,7 @@ class Okareo:
         """
 
         uploaded_data: List[SeedDataRow] = []
+        project_id = self._resolved_project_id(project_id)
         pid = str(project_id) if project_id else None
         for item in tqdm(data_list, desc="Uploading audio files"):
             upload_response = self.upload_voice(
@@ -1823,8 +2058,8 @@ class Okareo:
 
     def ingest_conversations(
         self,
-        project_id: Union[str, UUID],
-        conversations: List[Dict[str, Any]],
+        project_id: Union[str, UUID, None] = None,
+        conversations: Optional[List[Dict[str, Any]]] = None,
         mut_id: Union[str, UUID, None] = None,
     ) -> Dict[str, Any]:
         """Ingest voice conversations for monitoring.
@@ -1899,6 +2134,14 @@ class Okareo:
         )
         ```
         """
+        project_id = self._resolved_project_id(project_id)
+        if project_id is None:
+            raise ValueError(
+                "ingest_conversations requires a project_id — pass one per call or "
+                "set a client-level Project (Okareo(..., project=...) or set_project)."
+            )
+        if conversations is None:
+            raise ValueError("ingest_conversations requires conversations.")
         payload = {
             "project_id": str(project_id),
             "conversations": conversations,

--- a/src/okareo_api_client/api/default/patch_project_v0_projects_project_id_patch.py
+++ b/src/okareo_api_client/api/default/patch_project_v0_projects_project_id_patch.py
@@ -1,0 +1,226 @@
+"""Hand-written client module for PATCH /v0/projects/{project_id}.
+
+NOT generated (regenerating the client wholesale is destructive — project-separation
+plan §7). Follows the shape of update_project_v0_projects_project_id_put.py with one
+deliberate difference: the backend's PATCH returns 200 (the PUT/GET routes keep their
+SDK-load-bearing 201), so the parser checks 200.
+"""
+
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+from uuid import UUID
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.error_response import ErrorResponse
+from ...models.project_patch_schema import ProjectPatchSchema
+from ...models.project_response import ProjectResponse
+from ...types import Response
+
+
+def _get_kwargs(
+    project_id: UUID,
+    *,
+    body: ProjectPatchSchema,
+    api_key: str,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    headers["api-key"] = api_key
+
+    _kwargs: dict[str, Any] = {
+        "method": "patch",
+        "url": "/v0/projects/{project_id}".format(
+            project_id=quote(str(project_id), safe=""),
+        ),
+    }
+
+    _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> ErrorResponse | ProjectResponse | None:
+    if response.status_code == 200:
+        response_200 = ProjectResponse.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 400:
+        response_400 = ErrorResponse.from_dict(response.json())
+
+        return response_400
+
+    if response.status_code == 401:
+        response_401 = ErrorResponse.from_dict(response.json())
+
+        return response_401
+
+    if response.status_code == 404:
+        response_404 = ErrorResponse.from_dict(response.json())
+
+        return response_404
+
+    if response.status_code == 422:
+        response_422 = ErrorResponse.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[ErrorResponse | ProjectResponse]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    project_id: UUID,
+    *,
+    client: AuthenticatedClient | Client,
+    body: ProjectPatchSchema,
+    api_key: str,
+) -> Response[ErrorResponse | ProjectResponse]:
+    """Patch Project
+
+     Partially update a project: name, tags and/or archive state. Only the fields
+    present in the request body are applied.
+
+    Args:
+        project_id (UUID): ID of the project
+        api_key (str):
+        body (ProjectPatchSchema):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[ErrorResponse | ProjectResponse]
+    """
+
+    kwargs = _get_kwargs(
+        project_id=project_id,
+        body=body,
+        api_key=api_key,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    project_id: UUID,
+    *,
+    client: AuthenticatedClient | Client,
+    body: ProjectPatchSchema,
+    api_key: str,
+) -> ErrorResponse | ProjectResponse | None:
+    """Patch Project
+
+     Partially update a project: name, tags and/or archive state. Only the fields
+    present in the request body are applied.
+
+    Args:
+        project_id (UUID): ID of the project
+        api_key (str):
+        body (ProjectPatchSchema):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        ErrorResponse | ProjectResponse | None
+    """
+
+    return sync_detailed(
+        project_id=project_id,
+        client=client,
+        body=body,
+        api_key=api_key,
+    ).parsed
+
+
+async def asyncio_detailed(
+    project_id: UUID,
+    *,
+    client: AuthenticatedClient | Client,
+    body: ProjectPatchSchema,
+    api_key: str,
+) -> Response[ErrorResponse | ProjectResponse]:
+    """Patch Project
+
+    Args:
+        project_id (UUID): ID of the project
+        api_key (str):
+        body (ProjectPatchSchema):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[ErrorResponse | ProjectResponse]
+    """
+
+    kwargs = _get_kwargs(
+        project_id=project_id,
+        body=body,
+        api_key=api_key,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    project_id: UUID,
+    *,
+    client: AuthenticatedClient | Client,
+    body: ProjectPatchSchema,
+    api_key: str,
+) -> ErrorResponse | ProjectResponse | None:
+    """Patch Project
+
+    Args:
+        project_id (UUID): ID of the project
+        api_key (str):
+        body (ProjectPatchSchema):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        ErrorResponse | ProjectResponse | None
+    """
+
+    return (
+        await asyncio_detailed(
+            project_id=project_id,
+            client=client,
+            body=body,
+            api_key=api_key,
+        )
+    ).parsed

--- a/src/okareo_api_client/models/__init__.py
+++ b/src/okareo_api_client/models/__init__.py
@@ -161,6 +161,7 @@ from .panel_table_config import PanelTableConfig
 from .panel_table_config_mode import PanelTableConfigMode
 from .pass_fail_check_result import PassFailCheckResult
 from .project_response import ProjectResponse
+from .project_patch_schema import ProjectPatchSchema
 from .project_schema import ProjectSchema
 from .provider_integration_response import ProviderIntegrationResponse
 from .provider_integration_response_metadata import ProviderIntegrationResponseMetadata
@@ -396,6 +397,7 @@ __all__ = (
     "PanelTableConfigMode",
     "PassFailCheckResult",
     "ProjectResponse",
+    "ProjectPatchSchema",
     "ProjectSchema",
     "ProviderIntegrationResponse",
     "ProviderIntegrationResponseMetadata",

--- a/src/okareo_api_client/models/project_patch_schema.py
+++ b/src/okareo_api_client/models/project_patch_schema.py
@@ -1,0 +1,77 @@
+"""Hand-written model for PATCH /v0/projects/{project_id}.
+
+NOT generated: regenerating the client wholesale is destructive (see the
+project-separation plan §7). Mirrors the backend's ProjectPatchSchema — all fields
+optional; only the keys actually set are sent (the backend applies exclude_unset
+semantics, and refuses explicit nulls with a 400).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="ProjectPatchSchema")
+
+
+@_attrs_define
+class ProjectPatchSchema:
+    """
+    Attributes:
+        name (str | Unset): Name of the project
+        tags (list[str] | Unset): Tags are strings that can be used to filter projects in the Okareo app
+        is_archived (bool | Unset): Archive state. Archived projects are hidden from the project
+            picker but remain fully usable.
+    """
+
+    name: str | Unset = UNSET
+    tags: list[str] | Unset = UNSET
+    is_archived: bool | Unset = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        if not isinstance(self.name, Unset):
+            field_dict["name"] = self.name
+        if not isinstance(self.tags, Unset):
+            field_dict["tags"] = self.tags
+        if not isinstance(self.is_archived, Unset):
+            field_dict["is_archived"] = self.is_archived
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        name = cast("str | Unset", d.pop("name", UNSET))
+        tags = cast("list[str] | Unset", d.pop("tags", UNSET))
+        is_archived = cast("bool | Unset", d.pop("is_archived", UNSET))
+
+        project_patch_schema = cls(
+            name=name,
+            tags=tags,
+            is_archived=is_archived,
+        )
+        project_patch_schema.additional_properties = d
+        return project_patch_schema
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties


### PR DESCRIPTION
## Why

Project separation gives every object an owning Project, but the SDK had no way to say which one. Callers either accepted the server's default or repeated `project_id` on every call.

## What a user gets

```python
okareo = Okareo(api_key=KEY, project="Support Team")   # name or id
okareo.set_project("QA Team")                           # switch mid-script; None clears
```

Names resolve because Project names are unique per organization. Matching ignores case and surrounding whitespace — names get copy-pasted out of the UI. A value that parses as a UUID is matched as an id and **never** falls back to a name lookup, so a wrong id fails loudly instead of quietly matching something else.

Anything unresolvable raises at construction, listing every Project as `name (id)`:

```
ValueError: Unknown project 'Billing Team'. Available Projects:
  Global (0156f5d7-…), Billing Agent (8a2b45f1-…)
```

Resolution reuses the Project list the constructor already fetches to validate the API key, so naming a Project costs **no extra request**.

## Precedence

Per-call value or explicitly-set field → client-level Project → server default.

- Methods taking `project_id=` default through it.
- Methods taking a caller-built payload get the field filled **on a copy** when it is `UNSET` — the caller's object is never mutated, and an explicit `None` still wins.
- Checks and Drivers are shared org-wide; the field is filled there for **provenance** (where the object was authored).

`upload_scenario_set` now resolves through this chain too. It was the one write that skipped it, so a client scoped to a Project still uploaded its scenarios to the **default** one — silently, since the upload succeeded and only the destination was wrong.

## Backward compatibility

Omitting a Project everywhere keeps today's behavior — the server resolves the default Project. **Existing scripts are unaffected.**

## Project lifecycle

`get_project()`, `update_project()`, `archive_project()`, `unarchive_project()`, over a hand-written PATCH client module (regenerating the full generated client would be destructive). Archiving is reversible and restricts nothing; the default Project can be neither renamed nor archived.

`create_project()` and `update_project()` **reject a name with leading or trailing whitespace before the request goes out**, matching the rule the server enforces. The round trip buys nothing when the answer is already known locally, and the local error names the corrected string:

```
ValueError: Project name ' Support Team' has leading or trailing whitespace.
Use 'Support Team' instead.
```

## Typing

The two Project helpers are generic over what they're handed rather than typed `Any` — a payload goes in and the same payload type comes out, and `_resolved_project_id` widens the caller's own type only by `str`. Typing them as `Any` silently switched off checking at every call site that assigned from them.

## Test fixes

- **Precedence tests rewritten to drive the public API** and assert on the outgoing request bodies, instead of reaching into internals. They now fail if precedence breaks anywhere between the call and the wire.
- **`Okareo.__init__.__defaults__` monkeypatch removed from all five sites.** Patching a positional-defaults tuple would have been silently misaligned by any new constructor keyword; the callback handler takes an explicit `base_path` parameter instead.
- **The live isolation test could not fail.** It asserted on Test Runs after creating a *Target*, so it passed whatever the backend did. It now lists Targets — the type it actually creates.
- **`@project_separation_deployed` gate removed.** The tests are meaningful exactly where they run — the backend's post-deploy `sdk-test-latest` job — and a gate defaulting to off is a test that never runs.
- **E2E tests reuse fixed scratch Projects**, created once and found by name thereafter. Projects can't be deleted and their names are unique per organization, so minting one per run both piles them up in the gate account and 400s on the second run under the new uniqueness rule. Where a test does need a fresh Project it takes a random suffix and archives it after.
- **Pre-flight fix** for the same rollout: the `get_projects()[0]` sites in `okareo_tests` select the default Project **by name** (`GET /v0/projects` had no `ORDER BY`, and the gate account accumulates Projects), and fail loudly when it's absent rather than falling back to an arbitrary row.

  > The plan also called for `ModelUnderTest.get_test_run` to pass the `project_id` it holds. **That was deliberately dropped and is not in this branch** — by-id gets keep id+org semantics, so the backend accepts no Project parameter on that route and the change would have been dead code. Noted because the plan named it as the item unblocking the deploy gate; it is not, and the gate is unblocked by the test fixes in this PR instead.

## Rollout order

⚠️ **This must publish to PyPI *before* the project-separation backend deploys** — the promote gate installs the published SDK.

## Testing

**34 hermetic unit tests** in `okareo_tests/test_client_project.py` (all network mocked) covering resolution by name and id, case/whitespace handling, the id-never-falls-back-to-name rule, precedence asserted on outgoing request bodies, fill-on-copy, local name validation, and the PATCH module's 200 parser. `pre-commit run --all-files` clean, `mypy` included.
