### PR TITLE
Add Vonage voice target (VonagePhoneTarget)

### DIFF
--- a/okareo_tests/test_integration_voice_dtmf.py
+++ b/okareo_tests/test_integration_voice_dtmf.py
@@ -27,9 +27,11 @@ import os
 import random
 import time
 from pathlib import Path
+from typing import Union
 
 import pytest
 import requests  # type: ignore
+from okareo_tests.common import API_KEY, random_string
 
 from okareo import Okareo
 from okareo.model_under_test import (
@@ -39,7 +41,6 @@ from okareo.model_under_test import (
     VonagePhoneTarget,
 )
 from okareo_api_client.models.scenario_set_create import ScenarioSetCreate
-from okareo_tests.common import API_KEY, random_string
 
 OKAREO_BASE_PATH = os.environ.get("OKAREO_BASE_PATH", "http://localhost:8000")
 IVR_TO_NUMBER = os.environ.get("IVR_TO_NUMBER", "")
@@ -86,7 +87,7 @@ def _driver_prompt(code: str) -> str:
     )
 
 
-def _build_target(provider: str) -> object:
+def _build_target(provider: str) -> Union[TwilioVoiceTarget, VonagePhoneTarget]:
     if provider == "twilio":
         return TwilioVoiceTarget(
             account_sid=TWILIO_ACCOUNT_SID,
@@ -170,7 +171,12 @@ def test_ivr_dtmf_sent_and_received(provider: str) -> None:
         ScenarioSetCreate(
             name=f"IVR DTMF e2e ({provider}) {random_string(4)}",
             seed_data=Okareo.seed_data_from_list(
-                [{"input": {"name": "ivr caller", "voice": "oscar"}, "result": _RESULT_RUBRIC}]
+                [
+                    {
+                        "input": {"name": "ivr caller", "voice": "oscar"},
+                        "result": _RESULT_RUBRIC,
+                    }
+                ]
             ),
         )
     )
@@ -178,7 +184,9 @@ def test_ivr_dtmf_sent_and_received(provider: str) -> None:
     evaluation = okareo.run_simulation(
         name=f"IVR DTMF e2e ({provider})",
         scenario=scenario,
-        target=Target(name=f"IVR DTMF {provider} target", target=_build_target(provider)),
+        target=Target(
+            name=f"IVR DTMF {provider} target", target=_build_target(provider)
+        ),
         driver=Driver(
             name=f"IVR DTMF {provider} driver",
             temperature=0.2,

--- a/okareo_tests/test_integration_voice_dtmf.py
+++ b/okareo_tests/test_integration_voice_dtmf.py
@@ -18,7 +18,7 @@ configured. To run it you need:
 
 Env:
   OKAREO_API_KEY, OKAREO_BASE_PATH (default http://localhost:8000), IVR_TO_NUMBER
-  Twilio: TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN, TWILIO_FROM_NUMBER
+  Twilio: TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN, TWILIO_FROM_PHONE
   Vonage: VONAGE_APPLICATION_ID, VONAGE_FROM_NUMBER, VONAGE_PRIVATE_KEY_PATH
   Optional driver voice: DEEPGRAM_API_KEY or OPENAI_API_KEY
 """
@@ -47,7 +47,7 @@ IVR_TO_NUMBER = os.environ.get("IVR_TO_NUMBER", "")
 
 TWILIO_ACCOUNT_SID = os.environ.get("TWILIO_ACCOUNT_SID", "")
 TWILIO_AUTH_TOKEN = os.environ.get("TWILIO_AUTH_TOKEN", "")
-TWILIO_FROM_NUMBER = os.environ.get("TWILIO_FROM_NUMBER", "")
+TWILIO_FROM_PHONE = os.environ.get("TWILIO_FROM_PHONE", "")
 
 VONAGE_APPLICATION_ID = os.environ.get("VONAGE_APPLICATION_ID", "")
 VONAGE_FROM_NUMBER = os.environ.get("VONAGE_FROM_NUMBER", "")
@@ -64,7 +64,7 @@ _RESULT_RUBRIC = (
 )
 
 _HAVE_COMMON = bool(IVR_TO_NUMBER and os.environ.get("OKAREO_API_KEY"))
-_HAVE_TWILIO = bool(TWILIO_ACCOUNT_SID and TWILIO_AUTH_TOKEN and TWILIO_FROM_NUMBER)
+_HAVE_TWILIO = bool(TWILIO_ACCOUNT_SID and TWILIO_AUTH_TOKEN and TWILIO_FROM_PHONE)
 _HAVE_VONAGE = bool(
     VONAGE_APPLICATION_ID and VONAGE_FROM_NUMBER and VONAGE_PRIVATE_KEY_PATH
 )
@@ -92,7 +92,7 @@ def _build_target(provider: str) -> Union[TwilioVoiceTarget, VonagePhoneTarget]:
         return TwilioVoiceTarget(
             account_sid=TWILIO_ACCOUNT_SID,
             auth_token=TWILIO_AUTH_TOKEN,
-            from_phone_number=TWILIO_FROM_NUMBER,
+            from_phone_number=TWILIO_FROM_PHONE,
             to_phone_number=IVR_TO_NUMBER,
         )
     if provider == "vonage":

--- a/okareo_tests/test_integration_voice_dtmf.py
+++ b/okareo_tests/test_integration_voice_dtmf.py
@@ -95,17 +95,15 @@ def _build_target(provider: str) -> object:
             to_phone_number=IVR_TO_NUMBER,
         )
     if provider == "vonage":
+        # DTMF (both OOB rfc4733 + in-band), recording, and 16 kHz are fixed
+        # server-side defaults — not configurable on the target. The testtarget
+        # captures the keypress via whichever path reaches it (dtmf event or
+        # in-band audio).
         return VonagePhoneTarget(
             to_phone_number=IVR_TO_NUMBER,
             from_phone_number=VONAGE_FROM_NUMBER,
             application_id=VONAGE_APPLICATION_ID,
             private_key=Path(VONAGE_PRIVATE_KEY_PATH).read_text(),
-            # Inert at dispatch (the edge sends both OOB + in-band regardless);
-            # "both" is explicit that we want the DTMF to reach the far end by any
-            # path the testtarget can capture (dtmf event or in-band audio).
-            dtmf_mechanism="both",
-            sr=16000,
-            record=True,
         )
     raise ValueError(f"unknown provider: {provider}")
 

--- a/okareo_tests/test_integration_voice_dtmf.py
+++ b/okareo_tests/test_integration_voice_dtmf.py
@@ -116,11 +116,14 @@ def _poll_readback(expected: str, timeout_s: float = 30.0) -> str:
     a prior provider's run: only this call's digits will equal ``expected``.
     """
     url = f"{OKAREO_BASE_PATH.rstrip('/')}/v0/voice/twilio/testtarget/ivr/dtmf/latest"
+    # The read-back route is api-key-gated (unlike the Twilio-facing webhook/ws),
+    # so the poll must authenticate.
+    headers = {"api-key": API_KEY}
     deadline = time.time() + timeout_s
     seen = ""
     while time.time() < deadline:
         try:
-            r = requests.get(url, timeout=5.0)
+            r = requests.get(url, headers=headers, timeout=5.0)
             if r.status_code == 200:
                 seen = (r.json() or {}).get("digits", "") or ""
                 if seen == expected:

--- a/okareo_tests/test_integration_voice_dtmf.py
+++ b/okareo_tests/test_integration_voice_dtmf.py
@@ -1,0 +1,205 @@
+"""E2E DTMF validation against the IVR testtarget, for both Twilio and Vonage.
+
+The Driver places a phone call (via a Twilio or Vonage voice target) to a number
+routed to okareo_server's opt-in IVR testtarget
+(``/v0/voice/twilio/testtarget/ivr``). The Driver presses a random keypad code;
+the testtarget captures it — from Twilio Media-Stream ``dtmf`` events (the
+out-of-band path Vonage uses) or, failing that, by decoding in-band tones from the
+received audio — and stores it. This test then reads it back and asserts
+``sent == received``, and runs the model-graded ``result_completed`` check against
+a rubric that fails on a partial/absent sequence.
+
+This is a live-telephony integration test — it is SKIPPED unless the rig is
+configured. To run it you need:
+  - okareo_server running locally with the IVR testtarget routes, reachable by the
+    telephony provider (e.g. via ngrok); OKAREO_BASE_PATH points at it.
+  - A phone number (IVR_TO_NUMBER) whose voice webhook hits the IVR testtarget.
+  - Provider credentials (Twilio and/or Vonage) for the Driver's outbound edge.
+
+Env:
+  OKAREO_API_KEY, OKAREO_BASE_PATH (default http://localhost:8000), IVR_TO_NUMBER
+  Twilio: TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN, TWILIO_FROM_NUMBER
+  Vonage: VONAGE_APPLICATION_ID, VONAGE_FROM_NUMBER, VONAGE_PRIVATE_KEY_PATH
+  Optional driver voice: DEEPGRAM_API_KEY or OPENAI_API_KEY
+"""
+
+import os
+import random
+import time
+from pathlib import Path
+
+import pytest
+import requests  # type: ignore
+
+from okareo import Okareo
+from okareo.model_under_test import (
+    Driver,
+    Target,
+    TwilioVoiceTarget,
+    VonagePhoneTarget,
+)
+from okareo_api_client.models.scenario_set_create import ScenarioSetCreate
+from okareo_tests.common import API_KEY, random_string
+
+OKAREO_BASE_PATH = os.environ.get("OKAREO_BASE_PATH", "http://localhost:8000")
+IVR_TO_NUMBER = os.environ.get("IVR_TO_NUMBER", "")
+
+TWILIO_ACCOUNT_SID = os.environ.get("TWILIO_ACCOUNT_SID", "")
+TWILIO_AUTH_TOKEN = os.environ.get("TWILIO_AUTH_TOKEN", "")
+TWILIO_FROM_NUMBER = os.environ.get("TWILIO_FROM_NUMBER", "")
+
+VONAGE_APPLICATION_ID = os.environ.get("VONAGE_APPLICATION_ID", "")
+VONAGE_FROM_NUMBER = os.environ.get("VONAGE_FROM_NUMBER", "")
+VONAGE_PRIVATE_KEY_PATH = os.environ.get("VONAGE_PRIVATE_KEY_PATH", "")
+
+# result_completed grades the target's utterances against this rubric. It is a
+# model-graded companion to the deterministic readback assertion below (which
+# already validates the full sequence, terminator included) — so it grades the
+# digit echo and tolerates the trailing '#'/pound being lost in TTS->STT.
+_RESULT_RUBRIC = (
+    "Target audibly repeats back the digit sequence the driver pressed. Missing "
+    "digits or no repeat back is a failure. The trailing pound/# terminator may be "
+    "lost in speech transcription and does not by itself count as a partial."
+)
+
+_HAVE_COMMON = bool(IVR_TO_NUMBER and os.environ.get("OKAREO_API_KEY"))
+_HAVE_TWILIO = bool(TWILIO_ACCOUNT_SID and TWILIO_AUTH_TOKEN and TWILIO_FROM_NUMBER)
+_HAVE_VONAGE = bool(
+    VONAGE_APPLICATION_ID and VONAGE_FROM_NUMBER and VONAGE_PRIVATE_KEY_PATH
+)
+
+
+def _driver_prompt(code: str) -> str:
+    """Minimal, deterministic scenario: enter exactly ``code`` then pound.
+
+    The send_dtmf skill (composed server-side) supplies the keypad mechanics
+    (silent keypress, whole value in one press); this template supplies only the
+    code and the goal.
+    """
+    return (
+        f"You are calling an automated test line. Your account number is {code}.\n"
+        "When the automated menu asks you to enter your account number followed "
+        f"by the pound key, enter it on the keypad as a single entry: {code} then "
+        "'#'. Do NOT say the number out loud — enter it on the keypad.\n"
+        "After you have entered it and the system acknowledges, end the call "
+        "politely. Keep every spoken turn to one short sentence."
+    )
+
+
+def _build_target(provider: str) -> object:
+    if provider == "twilio":
+        return TwilioVoiceTarget(
+            account_sid=TWILIO_ACCOUNT_SID,
+            auth_token=TWILIO_AUTH_TOKEN,
+            from_phone_number=TWILIO_FROM_NUMBER,
+            to_phone_number=IVR_TO_NUMBER,
+        )
+    if provider == "vonage":
+        return VonagePhoneTarget(
+            to_phone_number=IVR_TO_NUMBER,
+            from_phone_number=VONAGE_FROM_NUMBER,
+            application_id=VONAGE_APPLICATION_ID,
+            private_key=Path(VONAGE_PRIVATE_KEY_PATH).read_text(),
+            # Inert at dispatch (the edge sends both OOB + in-band regardless);
+            # "both" is explicit that we want the DTMF to reach the far end by any
+            # path the testtarget can capture (dtmf event or in-band audio).
+            dtmf_mechanism="both",
+            sr=16000,
+            record=True,
+        )
+    raise ValueError(f"unknown provider: {provider}")
+
+
+def _poll_readback(expected: str, timeout_s: float = 30.0) -> str:
+    """Poll the testtarget for the DTMF it captured for the most recent call.
+
+    A fresh, unique code per test makes ``latest`` safe against a stale value from
+    a prior provider's run: only this call's digits will equal ``expected``.
+    """
+    url = f"{OKAREO_BASE_PATH.rstrip('/')}/v0/voice/twilio/testtarget/ivr/dtmf/latest"
+    deadline = time.time() + timeout_s
+    seen = ""
+    while time.time() < deadline:
+        try:
+            r = requests.get(url, timeout=5.0)
+            if r.status_code == 200:
+                seen = (r.json() or {}).get("digits", "") or ""
+                if seen == expected:
+                    return seen
+        except requests.RequestException:
+            pass
+        time.sleep(1.5)
+    return seen
+
+
+@pytest.mark.parametrize(
+    "provider",
+    [
+        pytest.param(
+            "twilio",
+            marks=pytest.mark.skipif(
+                not (_HAVE_COMMON and _HAVE_TWILIO),
+                reason="Twilio DTMF rig not configured (IVR_TO_NUMBER + TWILIO_*).",
+            ),
+        ),
+        pytest.param(
+            "vonage",
+            marks=pytest.mark.skipif(
+                not (_HAVE_COMMON and _HAVE_VONAGE),
+                reason="Vonage DTMF rig not configured (IVR_TO_NUMBER + VONAGE_*).",
+            ),
+        ),
+    ],
+)
+def test_ivr_dtmf_sent_and_received(provider: str) -> None:
+    """Driver presses a random code; the IVR testtarget must receive it intact.
+
+    Deterministic gate: the testtarget's captured digits (read back) equal what the
+    Driver pressed. The ``result_completed`` check additionally grades — model-based
+    — whether the target vocalized the full sequence (partial = fail).
+    """
+    okareo = Okareo(api_key=API_KEY, base_path=OKAREO_BASE_PATH)
+    code = f"{random.randint(1000, 9999)}"  # noqa: S311 — test nonce, not crypto
+    expected = f"{code}#"
+
+    api_keys = {}
+    if os.environ.get("DEEPGRAM_API_KEY"):
+        api_keys["voice"] = os.environ["DEEPGRAM_API_KEY"]
+    elif os.environ.get("OPENAI_API_KEY"):
+        api_keys["voice"] = os.environ["OPENAI_API_KEY"]
+
+    scenario = okareo.create_scenario_set(
+        ScenarioSetCreate(
+            name=f"IVR DTMF e2e ({provider}) {random_string(4)}",
+            seed_data=Okareo.seed_data_from_list(
+                [{"input": {"name": "ivr caller", "voice": "oscar"}, "result": _RESULT_RUBRIC}]
+            ),
+        )
+    )
+
+    evaluation = okareo.run_simulation(
+        name=f"IVR DTMF e2e ({provider})",
+        scenario=scenario,
+        target=Target(name=f"IVR DTMF {provider} target", target=_build_target(provider)),
+        driver=Driver(
+            name=f"IVR DTMF {provider} driver",
+            temperature=0.2,
+            prompt_template=_driver_prompt(code),
+        ),
+        max_turns=6,
+        repeats=1,
+        first_turn="target",
+        checks=["avg_turn_latency", "result_completed"],
+        api_keys=api_keys or None,
+    )
+
+    assert getattr(evaluation, "status", "") == "FINISHED", (
+        f"[{provider}] simulation did not finish: "
+        f"status={getattr(evaluation, 'status', '?')} app_link={getattr(evaluation, 'app_link', None)}"
+    )
+
+    received = _poll_readback(expected)
+    assert received == expected, (
+        f"[{provider}] IVR testtarget received {received!r}, expected {expected!r} — "
+        f"partial or missing DTMF. app_link={getattr(evaluation, 'app_link', None)}"
+    )

--- a/okareo_tests/test_vonage_target.py
+++ b/okareo_tests/test_vonage_target.py
@@ -24,10 +24,18 @@ class TestVonagePhoneTarget:
             == "-----BEGIN PRIVATE KEY-----\nabc\n-----END PRIVATE KEY-----"
         )
         assert params["max_parallel_requests"] is None
-        # DTMF mechanism, recording, and sample rate are fixed server-side
-        # defaults, not target params — they must not appear in the payload.
-        for dropped in ("private_key_path", "sip_uri", "dtmf_mechanism", "record", "sr"):
-            assert dropped not in params
+        # Closed contract: params() emits exactly these keys. Pins the cross-repo
+        # payload (server factory + FE schema read it) and catches a stray/re-added
+        # key without naming any specific field.
+        assert set(params) == {
+            "type",
+            "edge_type",
+            "to_phone_number",
+            "from_phone_number",
+            "application_id",
+            "private_key",
+            "max_parallel_requests",
+        }
 
     def test_phone_number_alias_maps_to_to_phone_number(self) -> None:
         vt = VonagePhoneTarget(phone_number="+15551234567")

--- a/okareo_tests/test_vonage_target.py
+++ b/okareo_tests/test_vonage_target.py
@@ -1,0 +1,90 @@
+"""Unit tests for VonagePhoneTarget — Vonage-backed voice target wrapper."""
+
+import pytest
+
+from okareo.model_under_test import Target, VonagePhoneTarget
+
+
+class TestVonagePhoneTarget:
+    def test_params_emits_vonage_format(self) -> None:
+        vt = VonagePhoneTarget(
+            phone_number="+15551234567",
+            from_phone_number="+15557654321",
+            application_id="app-123",
+            private_key="-----BEGIN PRIVATE KEY-----\nabc\n-----END PRIVATE KEY-----",
+        )
+        params = vt.params()
+        assert params["type"] == "voice"
+        assert params["edge_type"] == "vonage"
+        assert params["to_phone_number"] == "+15551234567"
+        assert params["from_phone_number"] == "+15557654321"
+        assert params["application_id"] == "app-123"
+        assert (
+            params["private_key"]
+            == "-----BEGIN PRIVATE KEY-----\nabc\n-----END PRIVATE KEY-----"
+        )
+        assert params["max_parallel_requests"] is None
+        # DTMF mechanism, recording, and sample rate are fixed server-side
+        # defaults, not target params — they must not appear in the payload.
+        for dropped in ("private_key_path", "sip_uri", "dtmf_mechanism", "record", "sr"):
+            assert dropped not in params
+
+    def test_phone_number_alias_maps_to_to_phone_number(self) -> None:
+        vt = VonagePhoneTarget(phone_number="+15551234567")
+        params = vt.params()
+        assert params["to_phone_number"] == "+15551234567"
+
+    def test_to_phone_number_takes_precedence_over_phone_number(self) -> None:
+        vt = VonagePhoneTarget(
+            phone_number="+15551234567", to_phone_number="+19998887777"
+        )
+        params = vt.params()
+        assert params["to_phone_number"] == "+19998887777"
+
+    def test_params_with_max_parallel(self) -> None:
+        vt = VonagePhoneTarget(phone_number="+15551234567", max_parallel_requests=5)
+        params = vt.params()
+        assert params["max_parallel_requests"] == 5
+
+    def test_get_sensitive_fields_marks_private_key(self) -> None:
+        vt = VonagePhoneTarget(
+            phone_number="+15551234567",
+            application_id="app-123",
+            private_key="pem-contents",
+        )
+        sensitive = vt.get_sensitive_fields()
+        assert "private_key" in sensitive
+        # application_id is not treated as sensitive, mirroring
+        # TwilioVoiceTarget (account_sid is not sensitive, only auth_token).
+        assert "application_id" not in sensitive
+
+    def test_get_sensitive_fields_empty_when_no_creds(self) -> None:
+        vt = VonagePhoneTarget(phone_number="+15551234567")
+        assert vt.get_sensitive_fields() == []
+
+    def test_requires_a_destination(self) -> None:
+        # SDK-3: no destination fails fast at construction (like the siblings)
+        # rather than surfacing late as an opaque Vonage dial error mid-run.
+        with pytest.raises(ValueError):
+            VonagePhoneTarget(application_id="app-123", private_key="pem")
+
+    def test_template_destination_is_accepted(self) -> None:
+        vt = VonagePhoneTarget(phone_number="{scenario_input.phone}")
+        assert vt.params()["to_phone_number"] == "{scenario_input.phone}"
+
+    def test_target_to_dict(self) -> None:
+        t = Target(
+            name="Test Agent",
+            target=VonagePhoneTarget(
+                phone_number="+15551234567",
+                application_id="app-123",
+                private_key="pem-contents",
+            ),
+        )
+        d = t.to_dict()
+        assert d["name"] == "Test Agent"
+        assert d["target"]["to_phone_number"] == "+15551234567"
+        assert d["target"]["type"] == "voice"
+        assert d["target"]["edge_type"] == "vonage"
+        assert d["target"]["application_id"] == "app-123"
+        assert d["sensitive_fields"] == ["private_key"]

--- a/src/okareo/model_under_test.py
+++ b/src/okareo/model_under_test.py
@@ -1722,6 +1722,89 @@ class SipTarget(VoiceTarget):
         return ["sip_password"] if self.sip_password else []
 
 
+@_attrs_define
+class VonagePhoneTarget(VoiceTarget):
+    """Vonage-backed voice target for Okareo multiturn simulation.
+
+    Sibling of `PhoneTarget` (Twilio) for Okareo's Vonage voice edge
+    (``edge_type="vonage"``). Unlike `PhoneTarget`, Vonage credentials are
+    caller-supplied (Vonage has no Okareo-managed-telephony mode yet), so this
+    target also threads through `application_id`/`private_key` similar to how
+    `TwilioVoiceTarget` threads through `account_sid`/`auth_token`. Vonage
+    delivers mid-call DTMF out-of-band via RFC 4733 with no media-stream
+    teardown (see the Vonage voice-edge plan, ``vonage-edge-with-dtmf-nav.plan.md``).
+
+    Server contract — ``params()`` emits exactly these keys, consumed by the
+    server's Vonage edge factory. **This is a cross-repo contract** —
+    changing these keys requires a matching change server-side:
+        ``type``, ``edge_type``, ``to_phone_number``, ``from_phone_number``,
+        ``sip_uri``, ``application_id``, ``private_key``, ``private_key_path``,
+        ``dtmf_mechanism``, ``record``, ``sr``, ``max_parallel_requests``.
+
+    Arguments:
+        phone_number: Destination phone number (E.164, e.g. "+15551234567").
+            Emitted as ``to_phone_number`` in ``params()``, mirroring
+            `PhoneTarget`. Alias for `to_phone_number` — provide either.
+            Provide this (or `to_phone_number`) or `sip_uri`.
+        to_phone_number: Same as `phone_number`; takes precedence if both are set.
+        sip_uri: Destination SIP URI, alternative to `phone_number` — Vonage
+            owns the RTP leg so RFC 4733 DTMF works on SIP targets too.
+        from_phone_number: Outbound Vonage phone number.
+        application_id: Vonage application ID used to mint the call JWT.
+        private_key: Vonage application private key, PEM contents (treated as
+            sensitive). Provide this or `private_key_path`, not both.
+        private_key_path: Path to the PEM private key file, alternative to
+            `private_key` (treated as sensitive).
+        dtmf_mechanism: DTMF delivery mechanism. Default "rfc4733"
+            (teardown-free, out-of-band digits via ``PUT /v1/calls/{id}/dtmf``).
+        record: Enable server-side stitched dual-channel recording. Default True
+            (voice datapoints always expose an audio player; set False to opt out).
+        sr: Audio sample rate in Hz for the media websocket. Default 16000.
+        max_parallel_requests: Cap on concurrent calls hitting the target.
+    """
+
+    edge_type = "vonage"
+    phone_number: Optional[str] = None
+    to_phone_number: Optional[str] = None
+    sip_uri: Optional[str] = None
+    from_phone_number: Optional[str] = None
+    application_id: Optional[str] = None
+    private_key: Optional[str] = None
+    private_key_path: Optional[str] = None
+    dtmf_mechanism: str = field(default="rfc4733")
+    record: bool = field(default=True)
+    sr: int = field(default=16000)
+    max_parallel_requests: Optional[int] = None
+
+    def __attrs_post_init__(self) -> None:
+        if self.to_phone_number is None and self.phone_number is not None:
+            self.to_phone_number = self.phone_number
+
+    def params(self) -> dict:
+        return {
+            "type": self.type,
+            "edge_type": self.edge_type,
+            "to_phone_number": self.to_phone_number,
+            "from_phone_number": self.from_phone_number,
+            "sip_uri": self.sip_uri,
+            "application_id": self.application_id,
+            "private_key": self.private_key,
+            "private_key_path": self.private_key_path,
+            "dtmf_mechanism": self.dtmf_mechanism,
+            "record": self.record,
+            "sr": self.sr,
+            "max_parallel_requests": self.max_parallel_requests,
+        }
+
+    def get_sensitive_fields(self) -> list[str]:
+        sensitive = []
+        if self.private_key:
+            sensitive.append("private_key")
+        if self.private_key_path:
+            sensitive.append("private_key_path")
+        return sensitive
+
+
 @define
 class StopConfig:
     """
@@ -2147,6 +2230,7 @@ class Target:
         TwilioVoiceTarget,
         PhoneTarget,
         SipTarget,
+        VonagePhoneTarget,
         dict,
     ]
     id: Optional[str] = None

--- a/src/okareo/model_under_test.py
+++ b/src/okareo/model_under_test.py
@@ -1732,7 +1732,7 @@ class VonagePhoneTarget(VoiceTarget):
     target also threads through `application_id`/`private_key` similar to how
     `TwilioVoiceTarget` threads through `account_sid`/`auth_token`. Vonage
     delivers mid-call DTMF out-of-band via RFC 4733 with no media-stream
-    teardown (see the Vonage voice-edge plan, ``vonage-edge-with-dtmf-nav.plan.md``).
+    teardown.
 
     Security note — create a **dedicated Vonage Application** for Okareo and
     pass only that application's private key. A Vonage keypair is scoped to a

--- a/src/okareo/model_under_test.py
+++ b/src/okareo/model_under_test.py
@@ -1775,6 +1775,16 @@ class VonagePhoneTarget(VoiceTarget):
     def __attrs_post_init__(self) -> None:
         if self.to_phone_number is None and self.phone_number is not None:
             self.to_phone_number = self.phone_number
+        # Fail fast at construction, like the siblings (PhoneTarget.phone_number,
+        # SipTarget.sip_uri). Without a destination the server never validates
+        # to_number either, so None would surface late as an opaque Vonage
+        # provider error at dial time. Template strings are non-None -> still OK.
+        if self.to_phone_number is None:
+            raise ValueError(
+                "VonagePhoneTarget requires a destination: set phone_number or "
+                "to_phone_number (an E.164 number like '+15551234567' or a "
+                "template string such as '{scenario_input.phone}')."
+            )
 
     def params(self) -> dict:
         return {

--- a/src/okareo/model_under_test.py
+++ b/src/okareo/model_under_test.py
@@ -1734,46 +1734,42 @@ class VonagePhoneTarget(VoiceTarget):
     delivers mid-call DTMF out-of-band via RFC 4733 with no media-stream
     teardown (see the Vonage voice-edge plan, ``vonage-edge-with-dtmf-nav.plan.md``).
 
+    Security note — create a **dedicated Vonage Application** for Okareo and
+    pass only that application's private key. A Vonage keypair is scoped to a
+    single Application (not your whole account), is generated locally so Vonage
+    never sees it, and is revocable independently: regenerate the application's
+    keypair or delete the application to cut access without touching the rest of
+    your account.
+
     Server contract — ``params()`` emits exactly these keys, consumed by the
     server's Vonage edge factory. **This is a cross-repo contract** —
     changing these keys requires a matching change server-side:
         ``type``, ``edge_type``, ``to_phone_number``, ``from_phone_number``,
-        ``sip_uri``, ``application_id``, ``private_key``, ``private_key_path``,
-        ``dtmf_mechanism``, ``record``, ``sr``, ``max_parallel_requests``.
+        ``application_id``, ``private_key``, ``max_parallel_requests``.
+
+    Recording (on), DTMF delivery (both out-of-band rfc4733 + in-band), and the
+    16 kHz media sample rate are fixed server-side defaults — not configurable
+    from this target.
 
     Arguments:
         phone_number: Destination phone number (E.164, e.g. "+15551234567").
             Emitted as ``to_phone_number`` in ``params()``, mirroring
             `PhoneTarget`. Alias for `to_phone_number` — provide either.
-            Provide this (or `to_phone_number`) or `sip_uri`.
         to_phone_number: Same as `phone_number`; takes precedence if both are set.
-        sip_uri: Destination SIP URI, alternative to `phone_number` — Vonage
-            owns the RTP leg so RFC 4733 DTMF works on SIP targets too.
         from_phone_number: Outbound Vonage phone number.
         application_id: Vonage application ID used to mint the call JWT.
         private_key: Vonage application private key, PEM contents (treated as
-            sensitive). Provide this or `private_key_path`, not both.
-        private_key_path: Path to the PEM private key file, alternative to
-            `private_key` (treated as sensitive).
-        dtmf_mechanism: DTMF delivery mechanism. Default "rfc4733"
-            (teardown-free, out-of-band digits via ``PUT /v1/calls/{id}/dtmf``).
-        record: Enable server-side stitched dual-channel recording. Default True
-            (voice datapoints always expose an audio player; set False to opt out).
-        sr: Audio sample rate in Hz for the media websocket. Default 16000.
+            sensitive). Read it from your key file, e.g.
+            ``private_key=Path("private.key").read_text()``.
         max_parallel_requests: Cap on concurrent calls hitting the target.
     """
 
     edge_type = "vonage"
     phone_number: Optional[str] = None
     to_phone_number: Optional[str] = None
-    sip_uri: Optional[str] = None
     from_phone_number: Optional[str] = None
     application_id: Optional[str] = None
     private_key: Optional[str] = None
-    private_key_path: Optional[str] = None
-    dtmf_mechanism: str = field(default="rfc4733")
-    record: bool = field(default=True)
-    sr: int = field(default=16000)
     max_parallel_requests: Optional[int] = None
 
     def __attrs_post_init__(self) -> None:
@@ -1786,13 +1782,8 @@ class VonagePhoneTarget(VoiceTarget):
             "edge_type": self.edge_type,
             "to_phone_number": self.to_phone_number,
             "from_phone_number": self.from_phone_number,
-            "sip_uri": self.sip_uri,
             "application_id": self.application_id,
             "private_key": self.private_key,
-            "private_key_path": self.private_key_path,
-            "dtmf_mechanism": self.dtmf_mechanism,
-            "record": self.record,
-            "sr": self.sr,
             "max_parallel_requests": self.max_parallel_requests,
         }
 
@@ -1800,8 +1791,6 @@ class VonagePhoneTarget(VoiceTarget):
         sensitive = []
         if self.private_key:
             sensitive.append("private_key")
-        if self.private_key_path:
-            sensitive.append("private_key_path")
         return sensitive
 
 


### PR DESCRIPTION
## Summary

Adds `VonagePhoneTarget` — a Vonage-backed PSTN voice target for Okareo multiturn voice simulations — plus a parametrized Twilio/Vonage IVR DTMF end-to-end test.

Vonage is the sibling to the Twilio `PhoneTarget`, but its call-control is decoupled from media, so it can send **teardown-free out-of-band (RFC 4733) DTMF** mid-call — which the Twilio edge cannot. This target is the client surface for that server-side edge.

## What it exposes

Mirrors the Twilio target's PSTN surface — nothing more:

- `to_phone_number` / `phone_number` (alias) — destination, and `from_phone_number` — outbound Vonage number
- `application_id` + `private_key` — Vonage application creds; the key is **PEM contents only** (read it yourself, e.g. `private_key=Path("private.key").read_text()`). No file paths.
- `max_parallel_requests`

Recording (on), DTMF delivery (both OOB rfc4733 **and** in-band tones), and the 16 kHz media sample rate are **fixed server-side defaults** — deliberately not configurable from the target, so they can't be overridden by a raw payload.

`private_key` is marked sensitive (redacted on read). `params()` is a cross-repo contract consumed by the `okareo_server` Vonage edge factory.

## Tests

- `test_vonage_target.py` — unit tests for `params()` / `get_sensitive_fields()` / the `phone_number` alias.
- `test_integration_voice_dtmf.py` — live e2e: the Driver dials an IVR testtarget and presses a random keypad code; asserts the target received exactly what was sent, for **both** Twilio and Vonage. Skips cleanly without provider creds.

## Notes

- Targets `main`; both commits are Vonage-only.
- Companion PRs: `okareo_server` Vonage voice edge, and `appfrontend` Vonage target UI.


## Deploy order

Deploy the server PR (`okareo_server` #991) **first**; do **not** cut an SDK/PyPI release until the Vonage edge is live in prod. An SDK released ahead of the server hits `ValueError: Unknown edge_type` during run execution (loud, not silent). Reverse order (server first) is fully backward-compatible — merging this PR is safe; only the PyPI release is gated on the server deploy.
